### PR TITLE
Suggestion: Add `post_parent` to `wp_insert_post()`

### DIFF
--- a/includes/Plugin/RestApi/ResponsesController.php
+++ b/includes/Plugin/RestApi/ResponsesController.php
@@ -99,6 +99,7 @@ class ResponsesController extends \WP_REST_Posts_Controller {
 				),
 				'post_type'    => 'omniform_response',
 				'post_status'  => 'publish',
+				'post_parent'  => $form->get_id(),
 				'meta_input'   => array(
 					'_omniform_id'      => $form->get_id(),
 					'_omniform_user_ip' => $_SERVER['REMOTE_ADDR'],


### PR DESCRIPTION
Better for querying for the entries belonging to a form. 