### PR TITLE
Toolbar Addition: Set Fields or Fieldsets as Required

### DIFF
--- a/includes/BlockLibrary/Blocks/Textarea.php
+++ b/includes/BlockLibrary/Blocks/Textarea.php
@@ -20,7 +20,24 @@ class Textarea extends BaseControlBlock {
 		return sprintf(
 			'<textarea %s>%s</textarea>',
 			get_block_wrapper_attributes( $this->get_extra_wrapper_attributes() ),
-			esc_textarea( $this->get_block_attribute( 'fieldPlaceholder' ) )
+			esc_textarea( $this->get_block_attribute( 'fieldValue' ) )
 		);
+	}
+
+	/**
+	 * Gets the extra wrapper attributes for the field to be passed into get_block_wrapper_attributes().
+	 *
+	 * @return array
+	 */
+	public function get_extra_wrapper_attributes() {
+		$extra_attributes = wp_parse_args(
+			array(
+				'placeholder' => $this->get_block_attribute( 'fieldPlaceholder' ),
+				'aria-label'  => esc_attr( wp_strip_all_tags( $this->get_field_label() ) ),
+			),
+			parent::get_extra_wrapper_attributes()
+		);
+
+		return array_filter( $extra_attributes );
 	}
 }

--- a/packages/block-library/field/edit.js
+++ b/packages/block-library/field/edit.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
+	BlockControls,
 	InspectorControls,
 	useBlockProps,
 	useInnerBlocksProps,
@@ -13,9 +14,16 @@ import {
 	PanelBody,
 	TextControl,
 	ToggleControl,
+	ToolbarButton,
+	ToolbarGroup,
 } from '@wordpress/components';
 import { cleanForSlug } from '@wordpress/url';
 import { createBlock } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { Required } from '../shared/icons';
 
 const Edit = ( {
 	attributes: { fieldLabel, fieldName, isRequired },
@@ -111,18 +119,32 @@ const Edit = ( {
 		}
 	};
 
+	/**
+	 * Toggles the required attribute.
+	 */
+	const toggleRequired = () =>
+		setAttributes( { isRequired: ! isRequired } );
+
 	return (
 		<>
 			<div { ...innerBlockProps } />
+			<BlockControls>
+				<ToolbarGroup>
+					<ToolbarButton
+						icon={ Required }
+						isActive={ isRequired }
+						label={ __( 'Required for submission', 'omniform' ) }
+						onClick={ toggleRequired }
+					/>
+				</ToolbarGroup>
+			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Field Settings', 'omniform' ) }>
 
 					<ToggleControl
 						label={ __( 'Required for submission', 'omniform' ) }
 						checked={ isRequired }
-						onChange={ () => {
-							setAttributes( { isRequired: ! isRequired } );
-						} }
+						onChange={ toggleRequired }
 						help={ __( 'A value is required or must be check for the form to be submittable.', 'omniform' ) }
 					/>
 

--- a/packages/block-library/fieldset/edit.js
+++ b/packages/block-library/fieldset/edit.js
@@ -8,7 +8,6 @@ import {
 	useBlockProps,
 	useInnerBlocksProps,
 	InspectorControls,
-	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
@@ -19,12 +18,15 @@ import {
 } from '@wordpress/components';
 import { cleanForSlug } from '@wordpress/url';
 import { useEntityProp } from '@wordpress/core-data';
-import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { Required } from '../shared/icons';
 
 const Edit = ( {
 	attributes: { fieldLabel, fieldName, isRequired },
 	setAttributes,
-	clientId,
 	context,
 } ) => {
 	// Manage the required label.
@@ -40,21 +42,11 @@ const Edit = ( {
 	const blockProps = useBlockProps();
 	const innerBlockProps = useInnerBlocksProps();
 
-	// Update all child field blocks with a new required setting.
-	const { updateBlockAttributes } = useDispatch( blockEditorStore );
-	const { getBlockOrder } = useSelect( ( select ) => select( blockEditorStore ), [] );
-
-	const updateRequired = ( newIsRequired ) => {
-		setAttributes( { isRequired: newIsRequired } );
-
-		// Update all child field Blocks to match.
-		const innerBlockClientIds = getBlockOrder( clientId );
-		innerBlockClientIds.forEach( ( innerBlockClientId ) => {
-			updateBlockAttributes( innerBlockClientId, {
-				isRequired: newIsRequired,
-			} );
-		} );
-	};
+	/**
+	 * Toggles the required attribute.
+	 */
+	const toggleRequired = () =>
+		setAttributes( { isRequired: ! isRequired } );
 
 	return (
 		<div { ...blockProps } >
@@ -94,9 +86,7 @@ const Edit = ( {
 						icon={ Required }
 						isActive={ isRequired }
 						label={ __( 'Required for submission', 'omniform' ) }
-						onClick={ () => {
-							updateRequired( ! isRequired );
-						} }
+						onClick={ toggleRequired }
 					/>
 				</ToolbarGroup>
 			</BlockControls>
@@ -107,9 +97,7 @@ const Edit = ( {
 					<ToggleControl
 						label={ __( 'Required for submission', 'omniform' ) }
 						checked={ isRequired }
-						onChange={ () => {
-							updateRequired( ! isRequired );
-						} }
+						onChange={ toggleRequired }
 						help={ __( 'Set default \'required\' state for all fields in the group.', 'omniform' ) }
 					/>
 

--- a/packages/block-library/fieldset/edit.js
+++ b/packages/block-library/fieldset/edit.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import {
+	BlockControls,
 	RichText,
 	useBlockProps,
 	useInnerBlocksProps,
@@ -13,6 +14,8 @@ import {
 	PanelBody,
 	TextControl,
 	ToggleControl,
+	ToolbarButton,
+	ToolbarGroup,
 } from '@wordpress/components';
 import { cleanForSlug } from '@wordpress/url';
 import { useEntityProp } from '@wordpress/core-data';
@@ -84,6 +87,19 @@ const Edit = ( {
 			</div>
 
 			<div { ...innerBlockProps } />
+
+			<BlockControls>
+				<ToolbarGroup>
+					<ToolbarButton
+						icon={ Required }
+						isActive={ isRequired }
+						label={ __( 'Required for submission', 'omniform' ) }
+						onClick={ () => {
+							updateRequired( ! isRequired );
+						} }
+					/>
+				</ToolbarGroup>
+			</BlockControls>
 
 			<InspectorControls>
 				<PanelBody title={ __( 'Fieldset Settings', 'omniform' ) }>


### PR DESCRIPTION
- Added  a toolbar button to field and fieldset blocks to allow setting a field or group of fields as required without having to open the inspector controls.
- Removing logic which sets inner field's isRequired attribute when the fieldset is required.