### PR TITLE
Add custom handlers for block splitting, replacing, removing, and merging

### DIFF
--- a/packages/block-library/field/index.js
+++ b/packages/block-library/field/index.js
@@ -28,13 +28,6 @@ registerBlockType( name, {
 			fieldLabel: __( 'Field Label', 'omniform' ),
 		},
 	},
-	merge: ( attributes, attributesToMerge ) => {
-		return {
-			fieldLabel:
-				( attributes.fieldLabel || '' ) +
-				( attributesToMerge.fieldLabel || '' ),
-		};
-	},
 	// Get block name from the option value.
 	__experimentalLabel: ( { fieldLabel } ) => fieldLabel && decodeEntities( fieldLabel ),
 } );

--- a/packages/block-library/hidden/edit.js
+++ b/packages/block-library/hidden/edit.js
@@ -4,15 +4,29 @@
 import { __ } from '@wordpress/i18n';
 import {
 	RichText,
+	store as blockEditorStore,
 	useBlockProps,
 } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
 import { cleanForSlug } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import {
+	onMerge,
+	onReplace,
+	onSplit,
+} from '../shared/rich-text-handlers';
 
 const Edit = ( {
 	attributes: { fieldValue, fieldName },
 	setAttributes,
 	isSelected,
+	clientId,
 } ) => {
+	const { getBlock } = useSelect( blockEditorStore );
+
 	const blockProps = useBlockProps();
 
 	return (
@@ -29,6 +43,10 @@ const Edit = ( {
 				} }
 				withoutInteractiveFormatting
 				allowedFormats={ [] }
+
+				onSplit={ ( ...args ) => onSplit( getBlock( clientId ), ...args ) }
+				onReplace={ ( ...args ) => onReplace( getBlock( clientId ), ...args ) }
+				onMerge={ ( ...args ) => onMerge( getBlock( clientId ), ...args ) }
 			/>
 			<RichText
 				identifier="fieldControl"
@@ -40,6 +58,10 @@ const Edit = ( {
 				onChange={ ( html ) => setAttributes( { fieldValue: html } ) }
 				withoutInteractiveFormatting
 				allowedFormats={ [] }
+
+				onSplit={ ( ...args ) => onSplit( getBlock( clientId ), ...args ) }
+				onReplace={ ( ...args ) => onReplace( getBlock( clientId ), ...args ) }
+				onMerge={ ( ...args ) => onMerge( getBlock( clientId ), ...args ) }
 			/>
 		</div>
 	);

--- a/packages/block-library/input/edit.js
+++ b/packages/block-library/input/edit.js
@@ -7,8 +7,17 @@ import {
 	store as blockEditorStore,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { useSelect, useDispatch } from '@wordpress/data';
-import { cloneBlock, createBlock } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import {
+	onMerge,
+	onRemove,
+	onReplace,
+	onSplit,
+} from '../shared/rich-text-handlers';
 
 const Edit = ( {
 	attributes: { fieldPlaceholder, fieldType },
@@ -21,98 +30,8 @@ const Edit = ( {
 		getBlockRootClientId,
 	} = useSelect( blockEditorStore );
 
-	const {
-		replaceBlocks,
-		selectBlock,
-	} = useDispatch( blockEditorStore );
-
 	const isTextInput = [ 'text', 'email', 'url', 'number', 'month', 'password', 'search', 'tel', 'week', 'hidden' ].includes( fieldType );
 	const isOptionInput = [ 'checkbox', 'radio' ].includes( fieldType );
-
-	/**
-	 * Handles splitting the parent field block.
-	 *
-	 * @param {string}  _value     The value of the field label.
-	 * @param {boolean} isOriginal Whether the field label is the original.
-	 * @return {Object} The new block.
-	 */
-	const onSplit = ( _value, isOriginal ) => {
-		let block;
-
-		const rootClientId = getBlockRootClientId( clientId );
-		const rootBlock = getBlock( rootClientId );
-
-		/**
-		 * Prepares the inner blocks of the new field block.
-		 *
-		 * @param {Array} innerBlocks The inner blocks of the parent field block.
-		 * @return {Array} The prepared inner blocks.
-		 */
-		const prepareInnerBlocks = ( innerBlocks ) => {
-			return innerBlocks.map(
-				( { name, attributes } ) => 'omniform/input' === name
-					? createBlock( name, { ...attributes, fieldPlaceholder: undefined, fieldValue: undefined } )
-					: createBlock( name, { style: attributes.style } )
-			);
-		};
-
-		if ( isOriginal ) {
-			block = cloneBlock(
-				rootBlock,
-				rootBlock.attributes,
-				! isOriginal && prepareInnerBlocks( rootBlock.innerBlocks )
-			);
-		} else {
-			block = createBlock(
-				'omniform/field',
-				{
-					...rootBlock.attributes,
-					fieldLabel: '',
-					fieldName: '',
-				},
-				prepareInnerBlocks( rootBlock.innerBlocks )
-			);
-		}
-
-		if ( isOriginal ) {
-			block.clientId = rootClientId;
-		}
-
-		return block;
-	};
-
-	/**
-	 * Handles replacing the parent field block.
-	 *
-	 * @param {Array}  blocks          The blocks to replace the parent field block with.
-	 * @param {number} indexToSelect   The index of the block to select.
-	 * @param {number} initialPosition The initial position of the caret.
-	 */
-	const onReplace = ( blocks, indexToSelect, initialPosition ) => {
-		replaceBlocks(
-			[ getBlockRootClientId( clientId ) ],
-			blocks,
-			indexToSelect,
-			initialPosition
-		);
-
-		// focus the label of the last field block inserted
-		selectLabelBlock( blocks[ indexToSelect ].clientId, -1 );
-	};
-
-	/**
-	 * Selects the label block of a field block.
-	 *
-	 * @param {string} fieldClientId   The client ID of the field block.
-	 * @param {number} initialPosition The initial position of the caret.
-	 */
-	const selectLabelBlock = ( fieldClientId, initialPosition = 0 ) => {
-		const labelBlock = getBlock( fieldClientId ).innerBlocks.filter(
-			( block ) => block.name === 'omniform/label'
-		)[ 0 ];
-
-		selectBlock( labelBlock.clientId, initialPosition );
-	};
 
 	const blockProps = useBlockProps();
 
@@ -130,8 +49,10 @@ const Edit = ( {
 				withoutInteractiveFormatting
 				allowedFormats={ [] }
 
-				onSplit={ onSplit }
-				onReplace={ onReplace }
+				onSplit={ ( ...args ) => onSplit( getBlock( getBlockRootClientId( clientId ) ), ...args ) }
+				onReplace={ ( ...args ) => onReplace( getBlock( getBlockRootClientId( clientId ) ), ...args ) }
+				onMerge={ ( ...args ) => onMerge( getBlock( getBlockRootClientId( clientId ) ), ...args ) }
+				onRemove={ ( ...args ) => onRemove( getBlock( getBlockRootClientId( clientId ) ), ...args ) }
 			/>
 		);
 	}

--- a/packages/block-library/select/edit.js
+++ b/packages/block-library/select/edit.js
@@ -15,12 +15,27 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 
+/**
+ * Internal dependencies
+ */
+import {
+	onMerge,
+	onRemove,
+	onReplace,
+	onSplit,
+} from '../shared/rich-text-handlers';
+
 const Edit = ( {
 	attributes: { fieldPlaceholder, isMultiple },
 	setAttributes,
 	isSelected,
 	clientId,
 } ) => {
+	const {
+		getBlock,
+		getBlockRootClientId,
+	} = useSelect( blockEditorStore );
+
 	const hasSelectedInnerBlock = useSelect(
 		( select ) => select( blockEditorStore ).hasSelectedInnerBlock( clientId, true ),
 		[ clientId ]
@@ -87,6 +102,11 @@ const Edit = ( {
 					onChange={ ( html ) => setAttributes( { fieldPlaceholder: html } ) }
 					withoutInteractiveFormatting
 					allowedFormats={ [] }
+
+					onSplit={ ( ...args ) => onSplit( getBlock( getBlockRootClientId( clientId ) ), ...args ) }
+					onReplace={ ( ...args ) => onReplace( getBlock( getBlockRootClientId( clientId ) ), ...args ) }
+					onMerge={ ( ...args ) => onMerge( getBlock( getBlockRootClientId( clientId ) ), ...args ) }
+					onRemove={ ( ...args ) => onRemove( getBlock( getBlockRootClientId( clientId ) ), ...args ) }
 				/>
 			) }
 

--- a/packages/block-library/shared/rich-text-handlers.js
+++ b/packages/block-library/shared/rich-text-handlers.js
@@ -1,0 +1,139 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+import {
+	cloneBlock,
+	createBlock,
+	getDefaultBlockName,
+} from '@wordpress/blocks';
+import { select, dispatch } from '@wordpress/data';
+
+/**
+ * Handles splitting a block.
+ *
+ * @param {Object}  targetBlock The target block.
+ * @param {string}  value       The value of the field label.
+ * @param {boolean} isOriginal  Whether the field label is the original.
+ *
+ * @return {Object} The new block.
+ */
+export function onSplit( targetBlock, value, isOriginal ) {
+	let block;
+
+	if ( isOriginal ) {
+		block = cloneBlock(
+			targetBlock,
+			targetBlock.attributes,
+			targetBlock.innerBlocks
+		);
+	} else {
+		block = createBlock(
+			targetBlock.name,
+			{ style: targetBlock.attributes.style },
+			targetBlock.innerBlocks.map(
+				( { name, attributes } ) => [ 'omniform/input', 'omniform/select', 'omniform/textarea' ].includes( name )
+					? createBlock( name, { fieldPlaceholder: undefined, fieldValue: undefined, fieldType: attributes.fieldType, style: attributes.style } )
+					: createBlock( name, { style: attributes.style } )
+			)
+		);
+	}
+
+	if ( isOriginal ) {
+		block.clientId = targetBlock.clientId;
+	}
+
+	return block;
+}
+
+/**
+ * Handles replacing the parent field block.
+ *
+ * @param {string} targetBlock     The target block.
+ * @param {Array}  blocks          The blocks to replace the parent field block with.
+ * @param {number} indexToSelect   The index of the block to select.
+ * @param {number} initialPosition The initial position of the caret.
+ */
+export function onReplace( targetBlock, blocks, indexToSelect, initialPosition ) {
+	const {
+		replaceBlocks,
+		selectBlock,
+	} = dispatch( blockEditorStore );
+
+	replaceBlocks(
+		[ targetBlock.clientId ],
+		blocks,
+		indexToSelect,
+		initialPosition
+	);
+
+	// Select the label block if it exists, otherwise select the input block.
+	const labelBlock = blocks[ indexToSelect ]?.innerBlocks.find( ( block ) => block.name === 'omniform/label' );
+	const inputBlock = blocks[ indexToSelect ]?.innerBlocks.find( ( block ) => [ 'omniform/input', 'omniform/textarea', 'omniform/select' ].includes( block.name ) );
+
+	if ( labelBlock ) {
+		selectBlock( labelBlock.clientId );
+	} else if ( inputBlock ) {
+		selectBlock( inputBlock.clientId );
+	} else {
+		selectBlock( blocks[ indexToSelect ].clientId );
+	}
+}
+
+/**
+ * Handles removing a block.
+ *
+ * @param {Object} targetBlock The target block.
+ */
+export function onRemove( targetBlock ) {
+	const {
+		removeBlock,
+	} = dispatch( blockEditorStore );
+
+	removeBlock( targetBlock.clientId );
+}
+
+/**
+ * Handles merging a block with the next or previous block.
+ *
+ * @param {Object}  targetBlock The target block.
+ * @param {boolean} forward     Whether to merge with the next block or the previous block.
+ */
+export function onMerge( targetBlock, forward ) {
+	const {
+		getNextBlockClientId,
+		getPreviousBlockClientId,
+	} = select( blockEditorStore );
+
+	const {
+		mergeBlocks,
+		replaceBlock,
+		selectBlock,
+	} = dispatch( blockEditorStore );
+
+	// If the target block is empty, replace it with a default block.
+	if (
+		( targetBlock.name === 'omniform/field' && ! targetBlock.attributes?.fieldLabel ) ||
+		( targetBlock.name === 'omniform/hidden' && ! targetBlock.attributes?.fieldName )
+	) {
+		const defaultBlock = createBlock( getDefaultBlockName() );
+		replaceBlock( targetBlock.clientId, defaultBlock );
+		selectBlock( defaultBlock.clientId );
+		return;
+	}
+
+	// Merge with the next or previous block normally.
+	if ( forward ) {
+		const nextBlockClientId = getNextBlockClientId( targetBlock.clientId );
+		if ( nextBlockClientId ) {
+			mergeBlocks( targetBlock.clientId, nextBlockClientId );
+		}
+	} else {
+		const previousBlockClientId = getPreviousBlockClientId( targetBlock.clientId );
+		if ( previousBlockClientId ) {
+			mergeBlocks( previousBlockClientId, targetBlock.clientId );
+		}
+	}
+}


### PR DESCRIPTION
This pull request adds custom handlers for block splitting, replacing, removing, and merging. It also updates the use of rich-text handlers in multiple blocks.