### PR TITLE
Add Support for Post Comment Forms

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# https://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/includes/BlockLibrary/BlockLibraryServiceProvider.php
+++ b/includes/BlockLibrary/BlockLibraryServiceProvider.php
@@ -87,6 +87,7 @@ class BlockLibraryServiceProvider extends AbstractServiceProvider implements Boo
 			Blocks\SelectOption::class,
 			Blocks\Captcha::class,
 			Blocks\ResponseNotification::class,
+			Blocks\PostCommentsFormTitle::class,
 		);
 
 		foreach ( $blocks as $block ) {

--- a/includes/BlockLibrary/BlockLibraryServiceProvider.php
+++ b/includes/BlockLibrary/BlockLibraryServiceProvider.php
@@ -89,6 +89,7 @@ class BlockLibraryServiceProvider extends AbstractServiceProvider implements Boo
 			Blocks\ResponseNotification::class,
 			Blocks\PostCommentsFormTitle::class,
 			Blocks\PostCommentsFormCancelReplyLink::class,
+			Blocks\ConditionalGroup::class,
 		);
 
 		foreach ( $blocks as $block ) {

--- a/includes/BlockLibrary/BlockLibraryServiceProvider.php
+++ b/includes/BlockLibrary/BlockLibraryServiceProvider.php
@@ -88,6 +88,7 @@ class BlockLibraryServiceProvider extends AbstractServiceProvider implements Boo
 			Blocks\Captcha::class,
 			Blocks\ResponseNotification::class,
 			Blocks\PostCommentsFormTitle::class,
+			Blocks\PostCommentsFormCancelReplyLink::class,
 		);
 
 		foreach ( $blocks as $block ) {

--- a/includes/BlockLibrary/Blocks/BaseControlBlock.php
+++ b/includes/BlockLibrary/Blocks/BaseControlBlock.php
@@ -8,11 +8,14 @@
 namespace OmniForm\BlockLibrary\Blocks;
 
 use OmniForm\Dependencies\Respect\Validation;
+use OmniForm\Traits\CallbackSupport;
 
 /**
  * The BaseControlBlock block class.
  */
 abstract class BaseControlBlock extends BaseBlock {
+	use CallbackSupport;
+
 	/**
 	 * Renders the block on the server.
 	 *
@@ -90,6 +93,7 @@ abstract class BaseControlBlock extends BaseBlock {
 			array(
 				'id'       => $this->get_field_name(),
 				'name'     => $this->get_control_name(),
+				'value'    => $this->get_control_value(),
 				'required' => $this->is_required(),
 				'class'    => $has_custom_border ? 'has-custom-border' : '',
 			)
@@ -123,6 +127,19 @@ abstract class BaseControlBlock extends BaseBlock {
 		return 2 === count( $parts )
 			? sprintf( '%s[%s]', $parts[0], $parts[1] )
 			: $parts[0];
+	}
+
+	/**
+	 * The form control's value attribute.
+	 *
+	 * @return string
+	 */
+	public function get_control_value() {
+		$value = $this->get_block_attribute( 'fieldValue' ) ?? '';
+
+		return $this->has_callback( $value )
+			? $this->process_callbacks( $value )
+			: $value;
 	}
 
 	/**

--- a/includes/BlockLibrary/Blocks/ConditionalGroup.php
+++ b/includes/BlockLibrary/Blocks/ConditionalGroup.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * The ConditionalGroup block class.
+ *
+ * @package OmniForm
+ */
+
+namespace OmniForm\BlockLibrary\Blocks;
+
+use OmniForm\Traits\CallbackSupport;
+
+/**
+ * The ConditionalGroup block class.
+ */
+class ConditionalGroup extends BaseBlock {
+	use CallbackSupport;
+
+	/**
+	 * Renders the block on the server.
+	 *
+	 * @return string
+	 */
+	public function render() {
+		if ( ! $this->has_callback( $this->get_block_attribute( 'callback' ) ?? '' ) ) {
+			return $this->content;
+		}
+
+		return empty( $this->process_callbacks( $this->get_block_attribute( 'callback' ) ) ) === $this->get_block_attribute( 'reverseCondition' )
+			? $this->content : '';
+	}
+}

--- a/includes/BlockLibrary/Blocks/Form.php
+++ b/includes/BlockLibrary/Blocks/Form.php
@@ -121,7 +121,7 @@ class Form extends BaseBlock {
 		return $this->get_form_wrapper(
 			$form->get_submit_method(),
 			$form->get_submit_action(),
-			do_blocks( $this->content ) . wp_nonce_field( 'omniform', 'wp_rest', true, false )
+			$this->process_callbacks( do_blocks( $this->content ) ) . wp_nonce_field( 'omniform', 'wp_rest', true, false )
 		);
 	}
 
@@ -186,7 +186,7 @@ class Form extends BaseBlock {
 		return $this->get_form_wrapper(
 			$this->get_block_attribute( 'submit_method' ) ?? 'POST',
 			$this->get_block_attribute( 'submit_action' ) ?? '',
-			do_blocks( $this->content ) . implode( '', $additional_fields )
+			$this->process_callbacks( do_blocks( $this->content ) ) . implode( '', $additional_fields )
 		);
 	}
 

--- a/includes/BlockLibrary/Blocks/Form.php
+++ b/includes/BlockLibrary/Blocks/Form.php
@@ -118,11 +118,9 @@ class Form extends BaseBlock {
 		 */
 		do_action( 'omniform_form_render', $form->get_id() );
 
-		return sprintf(
-			'<form method="%s" action="%s" %s>%s</form>',
-			esc_attr( strtolower( $form->get_submit_method() ) ),
-			esc_attr( $this->process_callbacks( $form->get_submit_action() ) ),
-			get_block_wrapper_attributes(),
+		return $this->get_form_wrapper(
+			$form->get_submit_method(),
+			$form->get_submit_action(),
 			do_blocks( $this->content ) . wp_nonce_field( 'omniform', 'wp_rest', true, false )
 		);
 	}
@@ -185,12 +183,45 @@ class Form extends BaseBlock {
 			$additional_fields[] = wp_nonce_field( 'omniform' . $form_hash, '_wpnonce', true, false );
 		}
 
-		return sprintf(
-			'<form method="%s" action="%s" %s>%s</form>',
-			esc_attr( strtolower( $this->get_block_attribute( 'submit_method' ) ?? 'POST' ) ),
-			esc_attr( $this->process_callbacks( $this->get_block_attribute( 'submit_action' ) ?? '' ) ),
-			get_block_wrapper_attributes(),
+		return $this->get_form_wrapper(
+			$this->get_block_attribute( 'submit_method' ) ?? 'POST',
+			$this->get_block_attribute( 'submit_action' ) ?? '',
 			do_blocks( $this->content ) . implode( '', $additional_fields )
+		);
+	}
+
+	/**
+	 * Returns the form wrapper.
+	 *
+	 * @param string $submit_method  The form submit method.
+	 * @param string $submit_action  The form submit action.
+	 * @param string $inner_content  The inner content.
+	 *
+	 * @return string The form wrapper.
+	 */
+	private function get_form_wrapper( $submit_method, $submit_action, $inner_content = '' ) {
+		$form_wrapper     = '<form method="%1$s" action="%2$s" %3$s>%4$s</form>';
+		$extra_attributes = array();
+
+		// Change the form wrapper for comment forms.
+		$submit_action = $this->process_callbacks( $submit_action );
+		if ( str_ends_with( $submit_action, '/wp-comments-post.php' ) ) {
+			$form_wrapper     = '<div %3$s><form method="%1$s" action="%2$s">%4$s</form></div>';
+			$extra_attributes = array(
+				'id'    => 'respond',
+				'class' => 'comment-respond',
+			);
+			// Enqueue the comment-reply script.
+			wp_enqueue_script( 'comment-reply' );
+			$inner_content .= get_comment_id_fields( $this->get_block_context( 'postId' ) );
+		}
+
+		return sprintf(
+			$form_wrapper,
+			esc_attr( strtolower( $submit_method ) ),
+			esc_attr( $submit_action ),
+			get_block_wrapper_attributes( $extra_attributes ),
+			$inner_content,
 		);
 	}
 

--- a/includes/BlockLibrary/Blocks/Hidden.php
+++ b/includes/BlockLibrary/Blocks/Hidden.php
@@ -7,14 +7,10 @@
 
 namespace OmniForm\BlockLibrary\Blocks;
 
-use OmniForm\Traits\CallbackSupport;
-
 /**
  * The Hidden block class.
  */
 class Hidden extends Input {
-	use CallbackSupport;
-
 	/**
 	 * Gets the field label.
 	 *
@@ -38,20 +34,5 @@ class Hidden extends Input {
 				'value' => $this->get_control_value(),
 			)
 		);
-	}
-
-	/**
-	 * The form control's value attribute.
-	 *
-	 * @return string
-	 */
-	public function get_control_value() {
-		$value = parent::get_control_value();
-
-		if ( $this->has_callback( $value ) ) {
-			$value = $this->process_callbacks( $value );
-		}
-
-		return esc_attr( $value );
 	}
 }

--- a/includes/BlockLibrary/Blocks/Input.php
+++ b/includes/BlockLibrary/Blocks/Input.php
@@ -8,14 +8,11 @@
 namespace OmniForm\BlockLibrary\Blocks;
 
 use OmniForm\Dependencies\Respect\Validation;
-use OmniForm\Traits\CallbackSupport;
 
 /**
  * The Input block class.
  */
 class Input extends BaseControlBlock {
-	use CallbackSupport;
-
 	const FORMAT_DATE           = 'Y-m-d';
 	const FORMAT_TIME           = 'h:i:s';
 	const FORMAT_MONTH          = 'Y-m';
@@ -44,7 +41,6 @@ class Input extends BaseControlBlock {
 			array(
 				'placeholder' => $this->get_block_attribute( 'fieldPlaceholder' ),
 				'type'        => $this->get_block_attribute( 'fieldType' ),
-				'value'       => $this->get_control_value(),
 				'aria-label'  => esc_attr( wp_strip_all_tags( $this->get_field_label() ) ),
 			),
 			parent::get_extra_wrapper_attributes()
@@ -60,13 +56,7 @@ class Input extends BaseControlBlock {
 	 */
 	public function get_control_value() {
 		if ( $this->get_block_attribute( 'fieldValue' ) ) {
-			$value = $this->get_block_attribute( 'fieldValue' );
-
-			if ( $this->has_callback( $value ) ) {
-				$value = $this->process_callbacks( $value );
-			}
-
-			return $value;
+			return parent::get_control_value();
 		}
 
 		switch ( $this->get_block_attribute( 'fieldType' ) ) {

--- a/includes/BlockLibrary/Blocks/PostCommentsFormCancelReplyLink.php
+++ b/includes/BlockLibrary/Blocks/PostCommentsFormCancelReplyLink.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * The PostCommentsFormCancelReplyLink block class.
+ *
+ * @package OmniForm
+ */
+
+namespace OmniForm\BlockLibrary\Blocks;
+
+/**
+ * The PostCommentsFormCancelReplyLink block class.
+ */
+class PostCommentsFormCancelReplyLink extends BaseBlock {
+	/**
+	 * Renders the block on the server.
+	 *
+	 * @return string
+	 */
+	public function render() {
+		$link_text = $this->get_block_attribute( 'linkText' );
+
+		$cancel_comment_reply_link = get_cancel_comment_reply_link(
+			$this->get_block_attribute( 'linkText' ),
+			$this->get_block_context( 'postId' )
+		);
+
+		return str_replace(
+			'<a',
+			'<a ' . get_block_wrapper_attributes(),
+			$cancel_comment_reply_link
+		);
+	}
+}

--- a/includes/BlockLibrary/Blocks/PostCommentsFormTitle.php
+++ b/includes/BlockLibrary/Blocks/PostCommentsFormTitle.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * The PostCommentsFormTitle block class.
+ *
+ * @package OmniForm
+ */
+
+namespace OmniForm\BlockLibrary\Blocks;
+
+/**
+ * The PostCommentsFormTitle block class.
+ */
+class PostCommentsFormTitle extends BaseBlock {
+	/**
+	 * Renders the block on the server.
+	 *
+	 * @return string
+	 */
+	public function render() {
+		$tag_name = 'h3';
+		if ( $this->get_block_attribute( 'level' ) ) {
+			$tag_name = 'h' . $this->get_block_attribute( 'level' );
+		}
+
+		$no_reply_text = $this->get_block_attribute( 'noReplyText' );
+		$reply_text    = trim( $this->get_block_attribute( 'replyText' ) );
+
+		ob_start();
+		comment_form_title(
+			empty( $no_reply_text ) ? false : $no_reply_text,
+			empty( $reply_text ) ? false : $reply_text,
+			true,
+			$this->get_block_context( 'postId' )
+		);
+		$comment_form_title = ob_get_clean();
+
+		return sprintf(
+			'<%1$s %2$s>%3$s</%1$s>',
+			esc_html( $tag_name ),
+			get_block_wrapper_attributes(
+				array(
+					'id'    => 'reply-title',
+					'class' => 'comment-reply-title',
+				)
+			),
+			$comment_form_title
+		);
+	}
+}

--- a/includes/Plugin/Support/Functions.php
+++ b/includes/Plugin/Support/Functions.php
@@ -34,3 +34,50 @@ function omniform_current_commenter_url() {
 	$commenter = wp_get_current_commenter();
 	return $commenter['comment_author_url'];
 }
+
+/**
+ * Check if the current user is required to login to comment.
+ *
+ * @return bool True if the user is required to login to comment, false otherwise.
+ */
+function omniform_comment_login_required() {
+	return comments_open() && get_option( 'comment_registration' ) && ! is_user_logged_in();
+}
+
+/**
+ * Check if comments are closed for the current post.
+ *
+ * @return bool True if comments are closed for the current post, false otherwise.
+ */
+function omniform_closed_for_comments() {
+	return ! comments_open();
+}
+
+/**
+ * Check if comments are open for the current post.
+ *
+ * @return bool True if comments are open for the current post, false otherwise.
+ */
+function omniform_open_for_comments() {
+	// Check if comments are open.
+	if ( ! comments_open() ) {
+		return false;
+	}
+
+	// If comment_registration is required, check if the user is logged in.
+	if ( get_option( 'comment_registration' ) ) {
+		return is_user_logged_in();
+	}
+
+	// If comment_registration is not required, allow comments.
+	return true;
+}
+
+/**
+ * Check if the comment cookies opt-in is enabled.
+ *
+ * @return bool True if the comment cookies opt-in is enabled, false otherwise.
+ */
+function omniform_comment_cookies_opt_in() {
+	return has_action( 'set_comment_cookies', 'wp_set_comment_cookies' ) && get_option( 'show_comments_cookies_opt_in' );
+}

--- a/includes/Plugin/Support/Functions.php
+++ b/includes/Plugin/Support/Functions.php
@@ -45,6 +45,24 @@ function omniform_comment_login_required() {
 }
 
 /**
+ * Get the login URL with redirect for the current post.
+ *
+ * @return string The login URL for the current post.
+ */
+function omniform_comment_login_url() {
+	return wp_login_url( get_permalink() );
+}
+
+/**
+ * Get the logout URL with redirect for the current post.
+ *
+ * @return string The logout URL for the current post.
+ */
+function omniform_comment_logout_url() {
+	return wp_logout_url( get_permalink() );
+}
+
+/**
  * Check if comments are closed for the current post.
  *
  * @return bool True if comments are closed for the current post, false otherwise.
@@ -80,4 +98,14 @@ function omniform_open_for_comments() {
  */
 function omniform_comment_cookies_opt_in() {
 	return has_action( 'set_comment_cookies', 'wp_set_comment_cookies' ) && get_option( 'show_comments_cookies_opt_in' );
+}
+
+/**
+ * Get the current user's display name.
+ *
+ * @return string The user's display name.
+ */
+function omniform_current_user_display_name() {
+	$user = wp_get_current_user();
+	return $user->exists() ? $user->display_name : '';
 }

--- a/packages/block-library/conditional-group/block.json
+++ b/packages/block-library/conditional-group/block.json
@@ -1,0 +1,26 @@
+{
+	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/6.3/schemas/json/block.json",
+	"apiVersion": 3,
+	"name": "omniform/conditional-group",
+	"category": "omniform",
+	"title": "Conditional Group",
+	"description": "Controls the visibility of a group of blocks based on specified conditions.",
+	"textdomain": "omniform",
+	"attributes": {
+		"callback": {
+			"type": "string"
+		},
+        "reverseCondition": {
+            "type": "boolean",
+            "default": false
+        }
+	},
+	"supports": {
+		"html": false,
+		"layout": {
+			"allowEditing": false
+		}
+	},
+	"editorScript": "file:index.js",
+	"editorStyle": "file:index.css"
+}

--- a/packages/block-library/conditional-group/edit.js
+++ b/packages/block-library/conditional-group/edit.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import {
 	BlockControls,
+	RichText,
 	useBlockProps,
 	useInnerBlocksProps,
 } from '@wordpress/block-editor';
@@ -41,7 +42,20 @@ const Edit = ( {
 				</ToolbarGroup>
 			</BlockControls>
 			<div { ...blockProps }>
-				<div className="condition-label">{ conditionLabel } { callback || '' }</div>
+				<div className="condition-label">
+					{ conditionLabel }
+					<RichText
+						identifier="callback"
+						placeholder={ __( 'Enter condition callback', 'omniform' ) }
+						value={ callback || '' }
+						onChange={ ( newCallback ) => {
+							setAttributes( { callback: newCallback } );
+						} }
+						withoutInteractiveFormatting
+						allowedFormats={ [] }
+						disableLineBreaks
+					/>
+				</div>
 				<div { ...innerBlockProps } />
 			</div>
 		</>

--- a/packages/block-library/conditional-group/edit.js
+++ b/packages/block-library/conditional-group/edit.js
@@ -1,0 +1,51 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	BlockControls,
+	useBlockProps,
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
+import {
+	ToolbarGroup,
+	ToolbarButton,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { iconReverseCondition } from '../shared/icons';
+
+const Edit = ( {
+	attributes: { callback, reverseCondition },
+	setAttributes,
+} ) => {
+	const blockProps = useBlockProps();
+	const innerBlockProps = useInnerBlocksProps();
+
+	const conditionLabel = reverseCondition
+		? __( 'Show when not', 'omniform' )
+		: __( 'Show when', 'omniform' );
+
+	return (
+		<>
+			<BlockControls>
+				<ToolbarGroup>
+					<ToolbarButton
+						icon={ iconReverseCondition }
+						isActive={ reverseCondition }
+						label={ __( 'Reverse condition', 'omniform' ) }
+						onClick={ () => setAttributes( { reverseCondition: ! reverseCondition } ) }
+					/>
+				</ToolbarGroup>
+			</BlockControls>
+			<div { ...blockProps }>
+				<div className="condition-label">{ conditionLabel } { callback || '' }</div>
+				<div { ...innerBlockProps } />
+			</div>
+		</>
+	);
+};
+
+export default Edit;

--- a/packages/block-library/conditional-group/index.js
+++ b/packages/block-library/conditional-group/index.js
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import json from './block.json';
+import Edit from './edit';
+import Save from './save';
+import { label as iconLabel } from '../shared/icons';
+
+import './index.scss';
+
+const { name } = json;
+
+registerBlockType( name, {
+	edit: Edit,
+	save: Save,
+	icon: { foreground: '#D92E83', src: iconLabel },
+} );

--- a/packages/block-library/conditional-group/index.scss
+++ b/packages/block-library/conditional-group/index.scss
@@ -7,11 +7,15 @@
 	padding-left: 1rem;
 
 	.condition-label {
-		display: block;
+		display: inline-flex;
+		flex-direction: row;
 		padding: 0.5rem 0;
 		font-size: 0.8em;
 		font-style: italic;
-		pointer-events: none;
 		color: var(--wp-admin-theme-color);
+
+		.rich-text {
+			margin-left: 1ch;
+		}
 	}
 }

--- a/packages/block-library/conditional-group/index.scss
+++ b/packages/block-library/conditional-group/index.scss
@@ -1,17 +1,17 @@
 .wp-block-omniform-conditional-group {
 
-    outline-color: var(--wp-admin-theme-color);
-    outline-offset: -1px;
-    outline-style: dashed;
-    outline-width: 1px;
-    padding-left: 1rem;
+	outline-color: var(--wp-admin-theme-color);
+	outline-offset: -1px;
+	outline-style: dashed;
+	outline-width: 1px;
+	padding-left: 1rem;
 
-    .condition-label {
-        display: block;
-        padding: 0.5rem 0;
-        font-size: 0.8em;
-        font-style: italic;
-        pointer-events: none;
-        color: var(--wp-admin-theme-color);
-    }
+	.condition-label {
+		display: block;
+		padding: 0.5rem 0;
+		font-size: 0.8em;
+		font-style: italic;
+		pointer-events: none;
+		color: var(--wp-admin-theme-color);
+	}
 }

--- a/packages/block-library/conditional-group/index.scss
+++ b/packages/block-library/conditional-group/index.scss
@@ -1,0 +1,17 @@
+.wp-block-omniform-conditional-group {
+
+    outline-color: var(--wp-admin-theme-color);
+    outline-offset: -1px;
+    outline-style: dashed;
+    outline-width: 1px;
+    padding-left: 1rem;
+
+    .condition-label {
+        display: block;
+        padding: 0.5rem 0;
+        font-size: 0.8em;
+        font-style: italic;
+        pointer-events: none;
+        color: var(--wp-admin-theme-color);
+    }
+}

--- a/packages/block-library/conditional-group/save.js
+++ b/packages/block-library/conditional-group/save.js
@@ -1,0 +1,9 @@
+/**
+ * WordPress dependencies
+ */
+import { useInnerBlocksProps, useBlockProps } from '@wordpress/block-editor';
+
+const Save = () => {
+	return useInnerBlocksProps.save( useBlockProps.save() ).children;
+};
+export default Save;

--- a/packages/block-library/fieldset/variations.js
+++ b/packages/block-library/fieldset/variations.js
@@ -2,49 +2,14 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { cleanFieldName } from '../shared/utils';
 
-const createInputField = ( fieldLabel, type, isRequired ) => {
-	const labelBlock = { name: 'omniform/label' };
-	const inputBlock = { name: 'omniform/input', attributes: { fieldType: type || 'text' } };
-
-	const layout = [ 'checkbox', 'radio' ].includes( type )
-		? { type: 'flex', orientation: 'horizontal', justifyContent: 'left' }
-		: undefined;
-
-	return ( {
-		name: 'omniform/field',
-		attributes: {
-			fieldLabel,
-			fieldName: cleanFieldName( fieldLabel ).toLowerCase(),
-			isRequired,
-			layout,
-		},
-		innerBlocks: [ 'checkbox', 'radio' ].includes( type )
-			? [ inputBlock, labelBlock ]
-			: [ labelBlock, inputBlock ],
-	} );
-};
-
-const createSelectBlock = ( fieldLabel, options, isRequired ) => {
-	const labelBlock = { name: 'omniform/label' };
-	const inputBlock = { name: 'omniform/select', attributes: { fieldPlaceholder: __( 'Select One', 'omniform' ), isMultiple: false } };
-
-	inputBlock.innerBlocks = options.map( ( option ) => ( {
-		name: 'omniform/select-option',
-		attributes: { fieldLabel: option },
-	} ) );
-
-	return ( {
-		name: 'omniform/field',
-		attributes: {
-			fieldLabel,
-			fieldName: cleanFieldName( fieldLabel ).toLowerCase(),
-			isRequired,
-		},
-		innerBlocks: [ labelBlock, inputBlock ],
-	} );
-};
+/**
+ * Internal dependencies
+ */
+import {
+	createInputField,
+	createSelectBlock,
+} from '../shared/variations';
 
 const variations = [
 	{

--- a/packages/block-library/form/variations.js
+++ b/packages/block-library/form/variations.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { createInputField, createTextareaField } from '../shared/variations';
 
 const variations = [
 	{
@@ -105,181 +106,167 @@ const variations = [
 				},
 				innerBlocks: [
 					{
-						name: 'core/heading',
-						attributes: {
-							content: 'Leave a Reply',
-							level: 3,
-							anchor: 'reply-title',
-						},
-						innerBlocks: [],
-					},
-					{
-						name: 'core/paragraph',
-						attributes: {
-							content: 'Your email address will not be published. Required fields are marked *',
-							dropCap: false,
-						},
-						innerBlocks: [],
-					},
-					{
-						name: 'omniform/field',
-						attributes: {
-							fieldLabel: 'Comment',
-							fieldName: 'comment',
-							isRequired: true,
-						},
-						innerBlocks: [
-							{
-								name: 'omniform/label',
-								attributes: {},
-								innerBlocks: [],
-							},
-							{
-								name: 'omniform/textarea',
-								attributes: {
-									className: 'comment-form-comment',
-									style: {
-										dimensions: {
-											minHeight: '230px',
-										},
-									},
-								},
-								innerBlocks: [],
-							},
-						],
-					},
-					{
-						name: 'omniform/field',
-						attributes: {
-							fieldLabel: 'Name',
-							fieldName: 'author',
-							isRequired: true,
-						},
-						innerBlocks: [
-							{
-								name: 'omniform/label',
-								attributes: {},
-								innerBlocks: [],
-							},
-							{
-								name: 'omniform/input',
-								attributes: {
-									fieldType: 'text',
-									fieldPlaceholder: '',
-									fieldValue: '{{omniform_current_commenter_author}}',
-								},
-								innerBlocks: [],
-							},
-						],
-					},
-					{
-						name: 'omniform/field',
-						attributes: {
-							fieldLabel: 'Email',
-							fieldName: 'email',
-							isRequired: true,
-						},
-						innerBlocks: [
-							{
-								name: 'omniform/label',
-								attributes: {},
-								innerBlocks: [],
-							},
-							{
-								name: 'omniform/input',
-								attributes: {
-									fieldType: 'email',
-									fieldValue: '{{omniform_current_commenter_email}}',
-								},
-								innerBlocks: [],
-							},
-						],
-					},
-					{
-						name: 'omniform/field',
-						attributes: {
-							fieldLabel: 'Website',
-							fieldName: 'url',
-						},
-						innerBlocks: [
-							{
-								name: 'omniform/label',
-								attributes: {},
-								innerBlocks: [],
-							},
-							{
-								name: 'omniform/input',
-								attributes: {
-									fieldType: 'url',
-									fieldPlaceholder: '',
-									fieldValue: '{{omniform_current_commenter_url}}',
-								},
-								innerBlocks: [],
-							},
-						],
-					},
-					{
-						name: 'omniform/field',
-						attributes: {
-							fieldLabel: 'Save my name, email, and website in this browser for the next time I comment.',
-							fieldName: 'wp-comment-cookies-consent',
-							layout: {
-								type: 'flex',
-								orientation: 'horizontal',
-								justifyContent: 'left',
-								flexWrap: 'nowrap',
-							},
-						},
-						innerBlocks: [
-							{
-								name: 'omniform/input',
-								attributes: {
-									fieldType: 'checkbox',
-								},
-								innerBlocks: [],
-							},
-							{
-								name: 'omniform/label',
-								attributes: {},
-								innerBlocks: [],
-							},
-						],
-					},
-					{
 						name: 'core/group',
 						attributes: {
 							tagName: 'div',
 							layout: {
 								type: 'flex',
 								flexWrap: 'nowrap',
+								verticalAlignment: 'center',
+								justifyContent: 'space-between',
 							},
 						},
 						innerBlocks: [
 							{
-								name: 'omniform/button',
+								name: 'omniform/post-comments-form-title',
 								attributes: {
-									buttonType: 'submit',
-									buttonLabel: 'Post Comment',
+									noReplyText: __( 'Leave a Reply', 'omniform' ),
+									/* translators: %s: author name */
+									replyText: __( 'Leave a Reply to %s', 'omniform' ),
+									linkToParent: true,
+									level: 3,
+								},
+								innerBlocks: [],
+							},
+							{
+								name: 'omniform/post-comments-form-cancel-reply-link',
+								attributes: {
+									linkText: __( 'Cancel reply', 'omniform' ),
 								},
 								innerBlocks: [],
 							},
 						],
 					},
 					{
-						name: 'omniform/hidden',
+						name: 'omniform/conditional-group',
 						attributes: {
-							fieldName: 'comment_post_ID',
-							fieldValue: '{{get_the_ID}}',
+							callback: '{{omniform_open_for_comments}}',
+							reverseCondition: false,
+							layout: {
+								type: 'default',
+							},
 						},
-						innerBlocks: [],
+						innerBlocks: [
+							{
+								name: 'omniform/conditional-group',
+								attributes: {
+									callback: '{{is_user_logged_in}}',
+									reverseCondition: false,
+									layout: {
+										type: 'default',
+									},
+								},
+								innerBlocks: [
+									{
+										name: 'core/paragraph',
+										attributes: {
+											content: __( 'Logged in as admin. <a href="/wp-admin/profile.php" data-type="link" data-id="/wp-admin/profile.php">Edit your profile</a>. <a href="/wp-login.php?action=logout" data-type="link" data-id="/wp-login.php?action=logout">Log out?</a> Required fields are marked *', 'omniform' ),
+											dropCap: false,
+										},
+										innerBlocks: [],
+									},
+								],
+							},
+							{
+								name: 'omniform/conditional-group',
+								attributes: {
+									callback: '{{is_user_logged_in}}',
+									reverseCondition: true,
+									layout: {
+										type: 'default',
+									},
+								},
+								innerBlocks: [
+									{
+										name: 'core/paragraph',
+										attributes: {
+											content: __( 'Your email address will not be published. Required fields are marked *', 'omniform' ),
+											dropCap: false,
+										},
+										innerBlocks: [],
+									},
+								],
+							},
+							createTextareaField( __( 'Comment', 'omniform' ), true ),
+							{
+								name: 'omniform/conditional-group',
+								attributes: {
+									callback: '{{is_user_logged_in}}',
+									reverseCondition: true,
+								},
+								innerBlocks: [
+									createInputField( __( 'Name', 'omniform' ), 'text', true, { fieldName: 'author', fieldValue: '{{omniform_current_commenter_author}}' } ),
+									createInputField( __( 'Email', 'omniform' ), 'text', true, { fieldName: 'email', fieldValue: '{{omniform_current_commenter_email}}' } ),
+									createInputField( __( 'Website', 'omniform' ), 'text', true, { fieldName: 'url', fieldValue: '{{omniform_current_commenter_url}}' } ),
+									{
+										name: 'omniform/conditional-group',
+										attributes: {
+											callback: '{{omniform_comment_cookies_opt_in}}',
+											reverseCondition: false,
+										},
+										innerBlocks: [
+											createInputField( __( 'Save my name, email, and website in this browser for the next time I comment.', 'omniform' ), 'checkbox', true, { fieldName: 'wp-comment-cookies-consent', fieldValue: '{{omniform_current_commenter_author}}' } ),
+										],
+									},
+								],
+							},
+							{
+								name: 'core/group',
+								attributes: {
+									tagName: 'div',
+									layout: {
+										type: 'flex',
+										flexWrap: 'nowrap',
+										justifyContent: 'left',
+										orientation: 'horizontal',
+									},
+								},
+								innerBlocks: [
+									{
+										name: 'omniform/button',
+										attributes: {
+											buttonType: 'submit',
+											buttonLabel: __( 'Post Comment', 'omniform' ),
+										},
+										innerBlocks: [],
+									},
+								],
+							},
+						],
 					},
 					{
-						name: 'omniform/hidden',
+						name: 'omniform/conditional-group',
 						attributes: {
-							fieldName: 'comment_parent',
-							fieldValue: '0',
+							callback: '{{omniform_closed_for_comments}}',
+							reverseCondition: false,
 						},
-						innerBlocks: [],
+						innerBlocks: [
+							{
+								name: 'core/paragraph',
+								attributes: {
+									content: __( 'Comments are closed.', 'omniform' ),
+									dropCap: false,
+								},
+								innerBlocks: [],
+							},
+						],
+					},
+					{
+						name: 'omniform/conditional-group',
+						attributes: {
+							callback: '{{omniform_comment_login_required}}',
+							reverseCondition: false,
+						},
+						innerBlocks: [
+							{
+								name: 'core/paragraph',
+								attributes: {
+									content: __( 'You must be <a href="/wp-login.php">logged in</a> to post a comment.', 'omniform' ),
+									dropCap: false,
+								},
+								innerBlocks: [],
+							},
+						],
 					},
 				],
 			},

--- a/packages/block-library/form/variations.js
+++ b/packages/block-library/form/variations.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { createInputField, createTextareaField } from '../shared/variations';
 
 const variations = [
@@ -113,7 +113,7 @@ const variations = [
 								type: 'flex',
 								flexWrap: 'nowrap',
 								verticalAlignment: 'center',
-								justifyContent: 'space-between',
+								justifyContent: 'left',
 							},
 						},
 						innerBlocks: [
@@ -160,7 +160,13 @@ const variations = [
 									{
 										name: 'core/paragraph',
 										attributes: {
-											content: __( 'Logged in as admin. <a href="/wp-admin/profile.php" data-type="link" data-id="/wp-admin/profile.php">Edit your profile</a>. <a href="/wp-login.php?action=logout" data-type="link" data-id="/wp-login.php?action=logout">Log out?</a> Required fields are marked *', 'omniform' ),
+											content: sprintf(
+												/* translators: 1: User name, 2: Edit user link, 3: Logout URL. */
+												__( 'Logged in as %1$s. <a href="%2$s">Edit your profile</a>. <a href="%3$s">Log out?</a> Required fields are marked *', 'omniform' ),
+												'{{omniform_current_user_display_name}}',
+												'{{get_edit_user_link}}',
+												'{{omniform_comment_logout_url}'
+											),
 											dropCap: false,
 										},
 										innerBlocks: [],
@@ -197,7 +203,7 @@ const variations = [
 								innerBlocks: [
 									createInputField( __( 'Name', 'omniform' ), 'text', true, { fieldName: 'author', fieldValue: '{{omniform_current_commenter_author}}' } ),
 									createInputField( __( 'Email', 'omniform' ), 'text', true, { fieldName: 'email', fieldValue: '{{omniform_current_commenter_email}}' } ),
-									createInputField( __( 'Website', 'omniform' ), 'text', true, { fieldName: 'url', fieldValue: '{{omniform_current_commenter_url}}' } ),
+									createInputField( __( 'Website', 'omniform' ), 'text', false, { fieldName: 'url', fieldValue: '{{omniform_current_commenter_url}}' } ),
 									{
 										name: 'omniform/conditional-group',
 										attributes: {
@@ -261,7 +267,11 @@ const variations = [
 							{
 								name: 'core/paragraph',
 								attributes: {
-									content: __( 'You must be <a href="/wp-login.php">logged in</a> to post a comment.', 'omniform' ),
+									content: sprintf(
+										/* translators: %s: Login URL. */
+										__( 'You must be <a href="%s">logged in</a> to post a comment.', 'omniform' ),
+										'{{omniform_comment_login_url}}'
+									),
 									dropCap: false,
 								},
 								innerBlocks: [],

--- a/packages/block-library/form/variations.js
+++ b/packages/block-library/form/variations.js
@@ -211,7 +211,7 @@ const variations = [
 											reverseCondition: false,
 										},
 										innerBlocks: [
-											createInputField( __( 'Save my name, email, and website in this browser for the next time I comment.', 'omniform' ), 'checkbox', true, { fieldName: 'wp-comment-cookies-consent', fieldValue: '{{omniform_current_commenter_author}}' } ),
+											createInputField( __( 'Save my name, email, and website in this browser for the next time I comment.', 'omniform' ), 'checkbox', false, { fieldName: 'wp-comment-cookies-consent', fieldValue: '{{omniform_current_commenter_author}}' } ),
 										],
 									},
 								],

--- a/packages/block-library/post-comments-form-cancel-reply-link/block.json
+++ b/packages/block-library/post-comments-form-cancel-reply-link/block.json
@@ -1,0 +1,22 @@
+{
+	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/6.3/schemas/json/block.json",
+	"apiVersion": 3,
+	"name": "omniform/post-comments-form-cancel-reply-link",
+	"category": "omniform",
+	"title": "Comments Form Cancel Reply Link",
+	"description": "Displays text based on comment reply status.",
+	"textdomain": "omniform",
+	"attributes": {
+		"linkText": {
+			"type": "string",
+			"default": "Cancel reply"
+		}
+	},
+	"supports": {
+		"html": false
+	},
+	"usesContext": [
+		"postId"
+	],
+	"editorScript": "file:index.js"
+}

--- a/packages/block-library/post-comments-form-cancel-reply-link/edit.js
+++ b/packages/block-library/post-comments-form-cancel-reply-link/edit.js
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	RichText,
+	useBlockProps,
+} from '@wordpress/block-editor';
+
+const Edit = ( {
+	attributes: { linkText },
+	setAttributes,
+} ) => {
+	const blockProps = useBlockProps();
+
+	return (
+		<RichText
+			identifier="linkText"
+			tagName={ 'a' }
+			placeholder={ __( 'Enter a title for the cancel reply link…', 'omniform' ) }
+			value={ linkText ?? '' }
+			onChange={ ( value ) => setAttributes( { linkText: value } ) }
+			{ ...blockProps }
+		/>
+	);
+};
+
+export default Edit;

--- a/packages/block-library/post-comments-form-cancel-reply-link/index.js
+++ b/packages/block-library/post-comments-form-cancel-reply-link/index.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import json from './block.json';
+import Edit from './edit';
+import { label as iconLabel } from '../shared/icons';
+
+const { name } = json;
+
+registerBlockType( name, {
+	edit: Edit,
+	icon: { foreground: '#D92E83', src: iconLabel },
+} );

--- a/packages/block-library/post-comments-form-cancel-reply-link/index.js
+++ b/packages/block-library/post-comments-form-cancel-reply-link/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 
 /**

--- a/packages/block-library/post-comments-form-title/block.json
+++ b/packages/block-library/post-comments-form-title/block.json
@@ -1,0 +1,34 @@
+{
+	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/6.3/schemas/json/block.json",
+	"apiVersion": 3,
+	"name": "omniform/post-comments-form-title",
+	"category": "omniform",
+	"title": "Comments Form Title",
+	"description": "Displays the title for the comments form.",
+	"textdomain": "omniform",
+	"attributes": {
+		"noReplyText": {
+			"type": "string",
+			"default": "Leave a Reply"
+		},
+		"replyText": {
+			"type": "string",
+			"default": "Leave a Reply to %s"
+		},
+		"linkToParent": {
+			"type": "boolean",
+			"default": true
+		},
+		"level": {
+			"type": "number",
+			"default": 3
+		}
+	},
+	"supports": {
+		"html": false
+	},
+	"usesContext": [
+		"postId"
+	],
+	"editorScript": "file:index.js"
+}

--- a/packages/block-library/post-comments-form-title/edit.js
+++ b/packages/block-library/post-comments-form-title/edit.js
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	BlockControls,
+	HeadingLevelDropdown,
+	RichText,
+	useBlockProps,
+} from '@wordpress/block-editor';
+
+const Edit = ( {
+	attributes: { noReplyText, level },
+	setAttributes,
+} ) => {
+	const blockProps = useBlockProps();
+
+	return (
+		<>
+			<BlockControls>
+				<HeadingLevelDropdown
+					value={ level }
+					onChange={ ( value ) => setAttributes( { level: value } ) }
+				/>
+			</BlockControls>
+			<RichText
+				identifier="noReplyText"
+				tagName={ 'h' + level }
+				placeholder={ __( 'Enter a title for the comment form…', 'omniform' ) }
+				value={ noReplyText ?? '' }
+				onChange={ ( value ) => setAttributes( { noReplyText: value } ) }
+				{ ...blockProps }
+			/>
+		</>
+	);
+};
+
+export default Edit;

--- a/packages/block-library/post-comments-form-title/index.js
+++ b/packages/block-library/post-comments-form-title/index.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import json from './block.json';
+import Edit from './edit';
+import { label as iconLabel } from '../shared/icons';
+
+const { name } = json;
+
+registerBlockType( name, {
+	edit: Edit,
+	icon: { foreground: '#D92E83', src: iconLabel },
+} );

--- a/packages/block-library/post-comments-form-title/index.js
+++ b/packages/block-library/post-comments-form-title/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 
 /**

--- a/packages/block-library/shared/icons.js
+++ b/packages/block-library/shared/icons.js
@@ -159,6 +159,12 @@ export const Required = (
 	</SVG>
 );
 
+export const iconReverseCondition = (
+	<SVG viewBox="0 0 24 24">
+		<Path d="m7 20-5-5 5-5 1.4 1.425L5.825 14H13v2H5.825L8.4 18.575 7 20Zm10-6-1.4-1.425L18.175 10H11V8h7.175L15.6 5.425 17 4l5 5-5 5Z" />
+	</SVG>
+);
+
 export const typeGeneral = (
 	<SVG viewBox="0 0 24 24">
 		<Path d="M7 7h2v2H7V7Z" />

--- a/packages/block-library/shared/mixins.scss
+++ b/packages/block-library/shared/mixins.scss
@@ -38,7 +38,8 @@
 	outline: 0 solid transparent;
 	outline-offset: -2px;
 
-	&:focus, &:focus-visible {
+	&:focus,
+	&:focus-visible {
 		outline: 2px solid currentcolor;
 		outline-offset: 2px;
 	}

--- a/packages/block-library/shared/variations.js
+++ b/packages/block-library/shared/variations.js
@@ -1,0 +1,62 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { cleanFieldName } from '../shared/utils';
+
+export const createInputField = ( fieldLabel, type, isRequired, extra = {} ) => {
+	const labelBlock = { name: 'omniform/label' };
+	const inputBlock = { name: 'omniform/input', attributes: { fieldType: type || 'text', fieldValue: extra?.fieldValue || '' } };
+
+	const layout = [ 'checkbox', 'radio' ].includes( type )
+		? { type: 'flex', orientation: 'horizontal', justifyContent: 'left', flexWrap: 'nowrap', verticalAlignment: 'center' }
+		: undefined;
+
+	return ( {
+		name: 'omniform/field',
+		attributes: {
+			fieldLabel,
+			fieldName: extra?.fieldName || cleanFieldName( fieldLabel ).toLowerCase(),
+			isRequired,
+			layout,
+		},
+		innerBlocks: [ 'checkbox', 'radio' ].includes( type )
+			? [ inputBlock, labelBlock ]
+			: [ labelBlock, inputBlock ],
+	} );
+};
+
+export const createSelectBlock = ( fieldLabel, options, isRequired, extra = {} ) => {
+	const labelBlock = { name: 'omniform/label' };
+	const inputBlock = { name: 'omniform/select', attributes: { fieldPlaceholder: __( 'Select One', 'omniform' ), isMultiple: false, fieldValue: extra?.fieldValue || '' } };
+
+	inputBlock.innerBlocks = options.map( ( option ) => ( {
+		name: 'omniform/select-option',
+		attributes: { fieldLabel: option },
+	} ) );
+
+	return ( {
+		name: 'omniform/field',
+		attributes: {
+			fieldLabel,
+			fieldName: extra?.fieldName || cleanFieldName( fieldLabel ).toLowerCase(),
+			isRequired,
+		},
+		innerBlocks: [ labelBlock, inputBlock ],
+	} );
+};
+
+export const createTextareaField = ( fieldLabel, isRequired, extra = {} ) => {
+	const labelBlock = { name: 'omniform/label' };
+	const textareaBlock = { name: 'omniform/textarea', attributes: { fieldValue: extra?.fieldValue || '', style: { dimensions: { minHeight: '230px' } } } };
+
+	return ( {
+		name: 'omniform/field',
+		attributes: {
+			fieldLabel,
+			fieldName: extra?.fieldName || cleanFieldName( fieldLabel ).toLowerCase(),
+			isRequired,
+		},
+		innerBlocks: [ labelBlock, textareaBlock ],
+	} );
+};


### PR DESCRIPTION
This PR introducs support for building and customizing post comment forms using blocks. It re-implements the core functionality of comment_form() within the block editor.