### PR TITLE
Handle lone checkboxes in response content display

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -12,11 +12,10 @@ jobs:
       matrix:
         php:
           - "7.4"
-          - "8.0"
-          - "8.1"
-          - "8.2"
+          - "8.3"
+          - "8.4"
         multisite: [false]
-        wordpress: ["6.4","6.3"]
+        wordpress: ["6.8","6.7"]
     env:
       WP_ENV_PHP_VERSION: ${{ matrix.php }}
       WP_ENV_CORE: ${{ format( 'https://wordpress.org/wordpress-{0}.zip', matrix.wordpress ) }}
@@ -43,7 +42,14 @@ jobs:
         run: composer install
 
       - name: Start Docker environment
-        run: npm run wp-env start
+        run: |
+          for i in {1..3}; do
+            if npm run wp-env start; then
+              break;
+            fi
+            echo "Retrying...";
+            sleep 10;
+          done
 
       - name: Running single site unit tests
         if: ${{ ! matrix.multisite }}

--- a/includes/Plugin/Response.php
+++ b/includes/Plugin/Response.php
@@ -102,11 +102,15 @@ class Response implements \JsonSerializable {
 		$message       = array();
 
 		foreach ( $response_data['fields'] as $name => $label ) {
-			$value     = implode( ', ', (array) $response_data['content']->get( $name, '' ) );
+			$value = implode( ', ', (array) $response_data['content']->get( $name, '' ) );
+
+			// Handle lone checkboxes.
+			$display_value = ( $label === $value ) ? 'Checked' : $value;
+
 			$message[] = sprintf(
 				'<strong>%s:</strong> %s',
 				esc_html( $label ),
-				wp_kses_post( nl2br( $value ), array() )
+				wp_kses_post( nl2br( $display_value ), array() )
 			);
 		}
 
@@ -123,8 +127,12 @@ class Response implements \JsonSerializable {
 		$message       = array();
 
 		foreach ( $response_data['fields'] as $name => $label ) {
-			$value     = implode( ', ', (array) $response_data['content']->get( $name, '' ) );
-			$message[] = $label . ': ' . wp_kses( $value, array() );
+			$value = implode( ', ', (array) $response_data['content']->get( $name, '' ) );
+
+			// Handle lone checkboxes.
+			$display_value = ( $label === $value ) ? 'Checked' : $value;
+
+			$message[] = $label . ': ' . wp_kses( $display_value, array() );
 		}
 
 		$message[] = '';


### PR DESCRIPTION
Adjust the display of response content to correctly show the status of lone checkboxes as 'Checked' when applicable.