### PR TITLE
Add explanation for 'Convert to Standard Form' button

### DIFF
--- a/packages/block-library/form/edit/inspector-controls.js
+++ b/packages/block-library/form/edit/inspector-controls.js
@@ -91,7 +91,7 @@ function StandaloneFormInspectorControls( { blockObject } ) {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const createFromBlocks = useCreateFormFromBlocks( blockObject.setAttributes, blockObject.attributes );
 
-	const [modalOpen, setModalOpen] = useState(false);
+	const [ modalOpen, setModalOpen ] = useState( false );
 
 	const createForm = async () => {
 		try {
@@ -137,19 +137,21 @@ function StandaloneFormInspectorControls( { blockObject } ) {
 					onChange={ ( newValue ) => setSetting( 'form_title', newValue ) }
 					help={ __( 'This name will not be visible to viewers and is only for identifying the form.', 'omniform' ) }
 				/>
-				<Text>{ __( 'Looking to track the performance of your form?', 'omniform' ) } <Button variant="link" onClick={() => setModalOpen(true)}>{ __( 'Learn more', 'omniform' ) }</Button></Text>
-				{modalOpen && (
-					<Modal onRequestClose={() => setModalOpen(false)} size="medium">
+				<Text>{ __( 'Looking to track the performance of your form?', 'omniform' ) } <Button variant="link" onClick={ () => setModalOpen( true ) }>{ __( 'Learn more', 'omniform' ) }</Button></Text>
+				{ modalOpen && (
+					<Modal onRequestClose={ () => setModalOpen( false ) } size="medium">
 						<Flex>
 							<Text><strong>{ __( 'Standalone Form:', 'omniform' ) }</strong> { __( 'Inline form that handles submissions directly and sends email notifications. No separate form management or analytics.', 'omniform' ) }</Text>
 							<Text><strong>{ __( 'Standard Form:', 'omniform' ) }</strong> { __( 'Stored form with advanced features like analytics, response tracking, and dedicated form editor for management and sharing.', 'omniform' ) }</Text>
 						</Flex>
 						<Flex justify="space-between">
-							<Button variant="secondary" onClick={() => setModalOpen(false)}>{ __( 'Cancel', 'omniform' ) }</Button>
-							<Button variant="primary" onClick={() => { createForm(); setModalOpen(false); }}>{ __( 'Upgrade to Standard Form', 'omniform' ) }</Button>
+							<Button variant="secondary" onClick={ () => setModalOpen( false ) }>{ __( 'Cancel', 'omniform' ) }</Button>
+							<Button variant="primary" onClick={ () => {
+								createForm(); setModalOpen( false );
+							} }>{ __( 'Upgrade to Standard Form', 'omniform' ) }</Button>
 						</Flex>
 					</Modal>
-				)}
+				) }
 			</PanelBody>
 			<EmailNotificationSettings
 				getSetting={ getSetting }

--- a/packages/block-library/form/edit/inspector-controls.js
+++ b/packages/block-library/form/edit/inspector-controls.js
@@ -156,15 +156,15 @@ function StandaloneFormInspectorControls( { blockObject } ) {
 								</Text>
 								<Flex>
 									<Text>
-										<strong>{ __( 'Analytics', 'omniform' ) }</strong>{ ' ' }
+										<strong>{ __( 'Analytics', 'omniform' ) }</strong>&nbsp;
 										{ __( 'for tracking submissions and engagement', 'omniform' ) }
 									</Text>
 									<Text>
-										<strong>{ __( 'Response tracking', 'omniform' ) }</strong>{ ' ' }
+										<strong>{ __( 'Response tracking', 'omniform' ) }</strong>&nbsp;
 										{ __( 'to manage and review form entries', 'omniform' ) }
 									</Text>
 									<Text>
-										<strong>{ __( 'Dedicated editor', 'omniform' ) }</strong>{ ' ' }
+										<strong>{ __( 'Dedicated editor', 'omniform' ) }</strong>&nbsp;
 										{ __( 'for easy customization and sharing', 'omniform' ) }
 									</Text>
 								</Flex>

--- a/packages/block-library/form/edit/inspector-controls.js
+++ b/packages/block-library/form/edit/inspector-controls.js
@@ -129,6 +129,11 @@ function StandaloneFormInspectorControls( { blockObject } ) {
 		}
 	};
 
+	const handleConvertForm = async () => {
+		await createForm();
+		setModalOpen( false );
+	};
+
 	return (
 		<InspectorControls>
 			<PanelBody title={ __( 'Form Settings', 'omniform' ) }>
@@ -145,7 +150,11 @@ function StandaloneFormInspectorControls( { blockObject } ) {
 					</Button>
 				</Text>
 				{ modalOpen && (
-					<Modal title={ __( 'Convert to Standard Form', 'omniform' ) } onRequestClose={ () => setModalOpen( false ) } size="medium">
+					<Modal
+						title={ __( 'Convert to Standard Form', 'omniform' ) }
+						onRequestClose={ () => setModalOpen( false ) }
+						size="medium"
+					>
 						<VStack spacing={ 8 }>
 							<VStack spacing={ 4 }>
 								<Text>
@@ -173,9 +182,7 @@ function StandaloneFormInspectorControls( { blockObject } ) {
 								<Button variant="secondary" onClick={ () => setModalOpen( false ) }>
 									{ __( 'Cancel', 'omniform' ) }
 								</Button>
-								<Button variant="primary" onClick={ () => {
-									createForm(); setModalOpen( false );
-								} }>
+								<Button variant="primary" onClick={ handleConvertForm }>
 									{ __( 'Convert Form', 'omniform' ) }
 								</Button>
 							</Flex>

--- a/packages/block-library/form/edit/inspector-controls.js
+++ b/packages/block-library/form/edit/inspector-controls.js
@@ -9,6 +9,7 @@ import {
 	PanelBody,
 	__experimentalText as Text,
 	TextControl,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import {
 	InspectorControls,
@@ -137,19 +138,48 @@ function StandaloneFormInspectorControls( { blockObject } ) {
 					onChange={ ( newValue ) => setSetting( 'form_title', newValue ) }
 					help={ __( 'This name will not be visible to viewers and is only for identifying the form.', 'omniform' ) }
 				/>
-				<Text>{ __( 'Looking to track the performance of your form?', 'omniform' ) } <Button variant="link" onClick={ () => setModalOpen( true ) }>{ __( 'Learn more', 'omniform' ) }</Button></Text>
+				<Text>
+					{ __( 'Want deeper insights into your form\'s performance?', 'omniform' ) }{' '}
+					<Button variant="link" onClick={ () => setModalOpen( true ) }>
+						{ __( 'Learn more', 'omniform' ) }
+					</Button>
+				</Text>
 				{ modalOpen && (
-					<Modal onRequestClose={ () => setModalOpen( false ) } size="medium">
-						<Flex>
-							<Text><strong>{ __( 'Standalone Form:', 'omniform' ) }</strong> { __( 'Inline form that handles submissions directly and sends email notifications. No separate form management or analytics.', 'omniform' ) }</Text>
-							<Text><strong>{ __( 'Standard Form:', 'omniform' ) }</strong> { __( 'Stored form with advanced features like analytics, response tracking, and dedicated form editor for management and sharing.', 'omniform' ) }</Text>
-						</Flex>
-						<Flex justify="space-between">
-							<Button variant="secondary" onClick={ () => setModalOpen( false ) }>{ __( 'Cancel', 'omniform' ) }</Button>
-							<Button variant="primary" onClick={ () => {
-								createForm(); setModalOpen( false );
-							} }>{ __( 'Upgrade to Standard Form', 'omniform' ) }</Button>
-						</Flex>
+					<Modal title={ __( 'Convert to Standard Form', 'omniform' ) } onRequestClose={ () => setModalOpen( false ) } size="medium">
+						<VStack spacing={ 8 }>
+							<VStack spacing={ 4 }>
+								<Text>
+									{ __( 'Your current form supports direct submissions and email notifications, but converting unlocks advanced features to help you get more from your form.', 'omniform' ) }
+								</Text>
+								<Text>
+									{ __( 'Convert to access:', 'omniform' ) }
+								</Text>
+								<Flex>
+									<Text>
+										<strong>{ __( 'Analytics', 'omniform' ) }</strong>{ ' ' }
+										{ __( 'for tracking submissions and engagement', 'omniform' ) }
+									</Text>
+									<Text>
+										<strong>{ __( 'Response tracking', 'omniform' ) }</strong>{ ' ' }
+										{ __( 'to manage and review form entries', 'omniform' ) }
+									</Text>
+									<Text>
+										<strong>{ __( 'Dedicated editor', 'omniform' ) }</strong>{ ' ' }
+										{ __( 'for easy customization and sharing', 'omniform' ) }
+									</Text>
+								</Flex>
+							</VStack>
+							<Flex justify="space-between">
+								<Button variant="secondary" onClick={ () => setModalOpen( false ) }>
+									{ __( 'Cancel', 'omniform' ) }
+								</Button>
+								<Button variant="primary" onClick={ () => {
+									createForm(); setModalOpen( false );
+								} }>
+									{ __( 'Convert Form', 'omniform' ) }
+								</Button>
+							</Flex>
+						</VStack>
 					</Modal>
 				) }
 			</PanelBody>

--- a/packages/block-library/form/edit/inspector-controls.js
+++ b/packages/block-library/form/edit/inspector-controls.js
@@ -139,7 +139,7 @@ function StandaloneFormInspectorControls( { blockObject } ) {
 					help={ __( 'This name will not be visible to viewers and is only for identifying the form.', 'omniform' ) }
 				/>
 				<Text>
-					{ __( 'Want deeper insights into your form\'s performance?', 'omniform' ) }{' '}
+					{ __( 'Want deeper insights into your form\'s performance?', 'omniform' ) }&nbsp;
 					<Button variant="link" onClick={ () => setModalOpen( true ) }>
 						{ __( 'Learn more', 'omniform' ) }
 					</Button>

--- a/packages/block-library/form/edit/inspector-controls.js
+++ b/packages/block-library/form/edit/inspector-controls.js
@@ -139,7 +139,7 @@ function StandaloneFormInspectorControls( { blockObject } ) {
 					help={ __( 'This name will not be visible to viewers and is only for identifying the form.', 'omniform' ) }
 				/>
 				<Text>
-					{ __( 'Want deeper insights into your form\'s performance?', 'omniform' ) }&nbsp;
+					{ __( 'Want deeper insights into your form\'s performance?', 'omniform' ) }{ ' ' }
 					<Button variant="link" onClick={ () => setModalOpen( true ) }>
 						{ __( 'Learn more', 'omniform' ) }
 					</Button>
@@ -156,15 +156,15 @@ function StandaloneFormInspectorControls( { blockObject } ) {
 								</Text>
 								<Flex>
 									<Text>
-										<strong>{ __( 'Analytics', 'omniform' ) }</strong>&nbsp;
+										<strong>{ __( 'Analytics', 'omniform' ) }</strong>{ ' ' }
 										{ __( 'for tracking submissions and engagement', 'omniform' ) }
 									</Text>
 									<Text>
-										<strong>{ __( 'Response tracking', 'omniform' ) }</strong>&nbsp;
+										<strong>{ __( 'Response tracking', 'omniform' ) }</strong>{ ' ' }
 										{ __( 'to manage and review form entries', 'omniform' ) }
 									</Text>
 									<Text>
-										<strong>{ __( 'Dedicated editor', 'omniform' ) }</strong>&nbsp;
+										<strong>{ __( 'Dedicated editor', 'omniform' ) }</strong>{ ' ' }
 										{ __( 'for easy customization and sharing', 'omniform' ) }
 									</Text>
 								</Flex>

--- a/packages/block-library/form/edit/inspector-controls.js
+++ b/packages/block-library/form/edit/inspector-controls.js
@@ -2,7 +2,14 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, PanelBody, TextControl } from '@wordpress/components';
+import {
+	Button,
+	Flex,
+	Modal,
+	PanelBody,
+	__experimentalText as Text,
+	TextControl,
+} from '@wordpress/components';
 import {
 	InspectorControls,
 	store as blockEditorStore,
@@ -10,6 +17,7 @@ import {
 import { addQueryArgs } from '@wordpress/url';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -83,6 +91,8 @@ function StandaloneFormInspectorControls( { blockObject } ) {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const createFromBlocks = useCreateFormFromBlocks( blockObject.setAttributes, blockObject.attributes );
 
+	const [modalOpen, setModalOpen] = useState(false);
+
 	const createForm = async () => {
 		try {
 			await createFromBlocks(
@@ -127,12 +137,19 @@ function StandaloneFormInspectorControls( { blockObject } ) {
 					onChange={ ( newValue ) => setSetting( 'form_title', newValue ) }
 					help={ __( 'This name will not be visible to viewers and is only for identifying the form.', 'omniform' ) }
 				/>
-				<Button
-					variant="primary"
-					onClick={ () => createForm() }
-				>
-					{ __( 'Convert to Standard Form', 'omniform' ) }
-				</Button>
+				<Text>{ __( 'Looking to track the performance of your form?', 'omniform' ) } <Button variant="link" onClick={() => setModalOpen(true)}>{ __( 'Learn more', 'omniform' ) }</Button></Text>
+				{modalOpen && (
+					<Modal onRequestClose={() => setModalOpen(false)} size="medium">
+						<Flex>
+							<Text><strong>{ __( 'Standalone Form:', 'omniform' ) }</strong> { __( 'Inline form that handles submissions directly and sends email notifications. No separate form management or analytics.', 'omniform' ) }</Text>
+							<Text><strong>{ __( 'Standard Form:', 'omniform' ) }</strong> { __( 'Stored form with advanced features like analytics, response tracking, and dedicated form editor for management and sharing.', 'omniform' ) }</Text>
+						</Flex>
+						<Flex justify="space-between">
+							<Button variant="secondary" onClick={() => setModalOpen(false)}>{ __( 'Cancel', 'omniform' ) }</Button>
+							<Button variant="primary" onClick={() => { createForm(); setModalOpen(false); }}>{ __( 'Upgrade to Standard Form', 'omniform' ) }</Button>
+						</Flex>
+					</Modal>
+				)}
 			</PanelBody>
 			<EmailNotificationSettings
 				getSetting={ getSetting }


### PR DESCRIPTION
The update introduces a modal that provides context for the "Convert to Standard Form" button, explaining the differences between Standalone and Standard forms.

Fixes #52

<img width="281" height="221" alt="image" src="https://github.com/user-attachments/assets/eca50575-53b5-452d-9b59-0308bebe02a4" />

<img width="1024" height="668" alt="Screen Shot 2025-10-06 at 22 45 19" src="https://github.com/user-attachments/assets/25c6c461-5068-47ed-8334-86255d6ce952" />