### PR TITLE
Add Username or Email Address Field

### DIFF
--- a/docs/blocks/input-block.md
+++ b/docs/blocks/input-block.md
@@ -2,6 +2,24 @@
 
 The Input block provides a basic field for text entry in forms, using an `<input>` element. It supports multiple input types, such as text, email, URL, and number, enabling you to define the expected format for user data.
 
+## Field Types
+
+The input block supports the following field types:
+
+- `text` - A single line text input.
+- `email` - An email input with email validation.
+- `url` - A URL input with URL validation.
+- `number` - A number input with number validation.
+- `tel` - A telephone number input with phone validation.
+- `password` - A password input.
+- `search` - A search input.
+- `date` - A date input with date validation.
+- `time` - A time input with time validation.
+- `month` - A month input with month validation.
+- `week` - A week input.
+- `hidden` - A hidden input.
+- `username-email` - A text input that accepts either a valid username or email address.
+
 To add a Input block, create a new form and open the Block Inserter tool. Use the search bar to find the Input block and click on its icon to insert it into the editor.
 
 You can also choose the Input block from the "Block Inserter" (+) pop-up window when you click on the (+) sign.

--- a/includes/BlockLibrary/Blocks/Input.php
+++ b/includes/BlockLibrary/Blocks/Input.php
@@ -8,6 +8,7 @@
 namespace OmniForm\BlockLibrary\Blocks;
 
 use OmniForm\Dependencies\Respect\Validation;
+use OmniForm\Validation\Rules\UsernameOrEmailRule;
 
 /**
  * The Input block class.
@@ -32,6 +33,20 @@ class Input extends BaseControlBlock {
 	}
 
 	/**
+	 * Gets the input type for the field.
+	 *
+	 * @return string
+	 */
+	protected function get_type(): string {
+		$field_type = $this->get_block_attribute( 'fieldType' ) ?? 'text';
+
+		return match ( $field_type ) {
+			'username-email' => 'text',
+			default => $field_type,
+		};
+	}
+
+	/**
 	 * Gets the extra wrapper attributes for the field to be passed into get_block_wrapper_attributes().
 	 *
 	 * @return array
@@ -40,7 +55,7 @@ class Input extends BaseControlBlock {
 		$extra_attributes = wp_parse_args(
 			array(
 				'placeholder' => $this->get_block_attribute( 'fieldPlaceholder' ),
-				'type'        => $this->get_block_attribute( 'fieldType' ),
+				'type'        => $this->get_type(),
 				'aria-label'  => esc_attr( wp_strip_all_tags( $this->get_field_label() ) ),
 			),
 			parent::get_extra_wrapper_attributes()
@@ -102,13 +117,14 @@ class Input extends BaseControlBlock {
 		$rules = parent::get_validation_rules();
 
 		$validation_mapping = array(
-			'email'  => new Validation\Rules\Email(),
-			'url'    => new Validation\Rules\Url(),
-			'tel'    => new Validation\Rules\Phone(),
-			'number' => new Validation\Rules\Number(),
-			'date'   => new Validation\Rules\Date( self::FORMAT_DATE ),
-			'time'   => new Validation\Rules\Time( self::FORMAT_TIME ),
-			'month'  => new Validation\Rules\Date( self::FORMAT_MONTH ),
+			'email'          => new Validation\Rules\Email(),
+			'url'            => new Validation\Rules\Url(),
+			'tel'            => new Validation\Rules\Phone(),
+			'number'         => new Validation\Rules\Number(),
+			'date'           => new Validation\Rules\Date( self::FORMAT_DATE ),
+			'time'           => new Validation\Rules\Time( self::FORMAT_TIME ),
+			'month'          => new Validation\Rules\Date( self::FORMAT_MONTH ),
+			'username-email' => new UsernameOrEmailRule(),
 		);
 
 		if ( isset( $validation_mapping[ $this->get_block_attribute( 'fieldType' ) ] ) ) {

--- a/includes/Validation/Rules/UsernameOrEmailRule.php
+++ b/includes/Validation/Rules/UsernameOrEmailRule.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * The UsernameOrEmailRule class.
+ *
+ * @package OmniForm
+ */
+
+namespace OmniForm\Validation\Rules;
+
+use OmniForm\Dependencies\Respect\Validation\Rules\AbstractRule;
+use OmniForm\Dependencies\Respect\Validation\Validator;
+
+/**
+ * The UsernameOrEmailRule class.
+ */
+class UsernameOrEmailRule extends AbstractRule {
+	/**
+	 * Validates the input.
+	 *
+	 * @param mixed $input Input to validate.
+	 *
+	 * @return bool
+	 */
+	public function validate( $input ): bool {
+		if ( Validator::email()->validate( $input ) ) {
+			return true;
+		}
+
+		if ( validate_username( $input ) ) {
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/packages/block-library/field/variations.js
+++ b/packages/block-library/field/variations.js
@@ -89,6 +89,16 @@ const variations = [
 		innerBlocks: inputTextExample( 'email' ).innerBlocks,
 	},
 	{
+		name: 'field-username-email',
+		category: 'omniform-standard-fields',
+		icon: { src: fieldInput },
+		title: __( 'Username or Email', 'omniform' ),
+		description: __( 'A field for collecting a username or email address.', 'omniform' ),
+		keywords: [ 'input', 'username', 'email', 'login' ],
+		example: inputTextExample( 'username-email', __( 'Username or Email', 'omniform' ) ),
+		innerBlocks: inputTextExample( 'username-email' ).innerBlocks,
+	},
+	{
 		name: 'field-url',
 		category: 'omniform-standard-fields',
 		icon: { src: fieldUrl },

--- a/packages/block-library/input/edit.js
+++ b/packages/block-library/input/edit.js
@@ -19,7 +19,7 @@ const Edit = ( {
 	clientId,
 	isSelected,
 } ) => {
-	const isTextInput = [ 'text', 'email', 'url', 'number', 'month', 'password', 'search', 'tel', 'week', 'hidden' ].includes( fieldType );
+	const isTextInput = [ 'text', 'email', 'url', 'number', 'month', 'password', 'search', 'tel', 'week', 'hidden', 'username-email' ].includes( fieldType );
 	const isOptionInput = [ 'checkbox', 'radio' ].includes( fieldType );
 
 	const blockProps = useBlockProps( {

--- a/packages/block-library/input/variations.js
+++ b/packages/block-library/input/variations.js
@@ -34,6 +34,13 @@ const variations = [
 		attributes: { fieldType: 'email' },
 	},
 	{
+		name: 'input-username-email',
+		icon: { src: fieldInput },
+		title: __( 'Username or Email', 'omniform' ),
+		description: __( 'A field for collecting a username or email address.', 'omniform' ),
+		attributes: { fieldType: 'username-email' },
+	},
+	{
 		name: 'input-url',
 		icon: { src: fieldUrl },
 		title: __( 'URL', 'omniform' ),

--- a/phpunit/includes/BlockLibrary/Blocks/InputTest.php
+++ b/phpunit/includes/BlockLibrary/Blocks/InputTest.php
@@ -38,7 +38,35 @@ class InputTest extends FormBlockTestCase {
 	}
 
 	/**
-	 * Default values should be returned unless the block has a fieldValue attribute.
+	 * Test get_validation_rules for email field type.
+	 */
+	public function test_get_validation_rules_email() {
+		$this->apply_block_context( 'omniform/fieldIsRequired', true );
+		$this->render_block_with_attributes( array( 'fieldType' => 'email' ) );
+
+		$rules = $this->block_instance->get_validation_rules();
+
+		$this->assertCount( 2, $rules );
+		$this->assertInstanceOf( 'OmniForm\Dependencies\Respect\Validation\Rules\NotEmpty', $rules[0] );
+		$this->assertInstanceOf( 'OmniForm\Dependencies\Respect\Validation\Rules\Email', $rules[1] );
+	}
+
+	/**
+	 * Test get_validation_rules for username-email field type.
+	 */
+	public function test_get_validation_rules_username_email() {
+		$this->apply_block_context( 'omniform/fieldIsRequired', true );
+		$this->render_block_with_attributes( array( 'fieldType' => 'username-email' ) );
+
+		$rules = $this->block_instance->get_validation_rules();
+
+		$this->assertCount( 2, $rules );
+		$this->assertInstanceOf( 'OmniForm\Dependencies\Respect\Validation\Rules\NotEmpty', $rules[0] );
+		$this->assertInstanceOf( 'OmniForm\Validation\Rules\UsernameOrEmailRule', $rules[1] );
+	}
+
+	/**
+	 * Test get_validation_rules for url field type.
 	 */
 	public function test_get_control_value() {
 		$field_label = 'field label';

--- a/phpunit/includes/Validation/Rules/UsernameOrEmailRuleTest.php
+++ b/phpunit/includes/Validation/Rules/UsernameOrEmailRuleTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * The UsernameOrEmailRuleTest class.
+ *
+ * @package OmniForm
+ */
+
+namespace OmniForm\Validation\Rules;
+
+use OmniForm\Validation\Rules\UsernameOrEmailRule;
+
+/**
+ * The UsernameOrEmailRuleTest class.
+ */
+class UsernameOrEmailRuleTest extends \WP_UnitTestCase {
+	/**
+	 * Test valid email.
+	 */
+	public function test_valid_email() {
+		$rule = new UsernameOrEmailRule();
+		$this->assertTrue( $rule->validate( 'test@example.com' ) );
+	}
+
+	/**
+	 * Test valid username.
+	 */
+	public function test_valid_username() {
+		$rule = new UsernameOrEmailRule();
+		$this->assertTrue( $rule->validate( 'test_user-123' ) );
+		$this->assertTrue( $rule->validate( 'user@' ) );
+	}
+
+	/**
+	 * Test invalid input.
+	 */
+	public function test_invalid_input() {
+		$rule = new UsernameOrEmailRule();
+		$this->assertFalse( $rule->validate( '' ) );
+	}
+}


### PR DESCRIPTION
Introduce a new input field type that allows users to enter either a username or an email address, along with validation for both formats. Update documentation and tests to support this new functionality.

Fixes #46