### PR TITLE
Add Color Picker Field

### DIFF
--- a/docs/blocks/input-block.md
+++ b/docs/blocks/input-block.md
@@ -1,6 +1,6 @@
 # Input Block
 
-The Input block provides a basic field for text entry in forms, using an `<input>` element. It supports multiple input types, such as text, email, URL, and number, enabling you to define the expected format for user data.
+The Input block provides a basic field for text entry in forms, using an `<input>` element. It supports multiple input types, such as text, email, URL, number, and color, enabling you to define the expected format for user data.
 
 ## Field Types
 
@@ -17,6 +17,7 @@ The input block supports the following field types:
 - `time` - A time input with time validation.
 - `month` - A month input with month validation.
 - `week` - A week input.
+- `color` - A color input with hex color validation.
 - `hidden` - A hidden input.
 - `username-email` - A text input that accepts either a valid username or email address.
 

--- a/includes/BlockLibrary/Blocks/Input.php
+++ b/includes/BlockLibrary/Blocks/Input.php
@@ -127,6 +127,7 @@ class Input extends BaseControlBlock {
 			'time'           => new Validation\Rules\Time( self::FORMAT_TIME ),
 			'month'          => new Validation\Rules\Date( self::FORMAT_MONTH ),
 			'username-email' => new UsernameOrEmailRule(),
+			'color'          => new Validation\Rules\HexRgbColor(),
 		);
 
 		if ( isset( $validation_mapping[ $this->get_block_attribute( 'fieldType' ) ] ) ) {

--- a/packages/block-library/field/variations.js
+++ b/packages/block-library/field/variations.js
@@ -215,6 +215,19 @@ const variations = [
 		innerBlocks: inputTextExample( 'time' ).innerBlocks,
 	},
 	{
+		name: 'field-color',
+		category: 'omniform-standard-fields',
+		icon: { src: fieldInput },
+		title: __( 'Color', 'omniform' ),
+		description: __( 'A field for selecting a color.', 'omniform' ),
+		keywords: [ 'input', 'color', 'picker' ],
+		attributes: {
+			className: 'is-style-inline',
+		},
+		example: inputTextExample( 'color', __( 'Color', 'omniform' ) ),
+		innerBlocks: inputTextExample( 'color' ).innerBlocks,
+	},
+	{
 		name: 'field-week',
 		category: 'omniform-standard-fields',
 		icon: { src: fieldDate },

--- a/packages/block-library/input/edit.js
+++ b/packages/block-library/input/edit.js
@@ -49,7 +49,7 @@ const Edit = ( {
 	}
 
 	return (
-		<input type={ fieldType } { ...blockProps } readOnly />
+		<input type={ fieldType } { ...blockProps } readOnly onClick={ ( event ) => event.preventDefault() } />
 	);
 };
 

--- a/packages/block-library/input/style.scss
+++ b/packages/block-library/input/style.scss
@@ -4,6 +4,31 @@
 
 	@include field-control;
 
+	// Color
+	&[type="color"] {
+		overflow: hidden;
+		background: none;
+		flex-shrink: 0;
+		flex-grow: unset;
+		width: 3.2em;
+		height: 1.6em;
+		padding: 0;
+
+		&::-moz-color-swatch-wrapper,
+		&::-webkit-color-swatch-wrapper {
+			display: block;
+			border: none;
+			padding: 0;
+		}
+
+		&::-moz-color-swatch,
+		&::-webkit-color-swatch {
+			border: none;
+			width: 100%;
+			height: 100%;
+		}
+	}
+
 	// Checkbox and Radio
 	&[type="checkbox"],
 	&[type="radio"] {

--- a/packages/block-library/input/variations.js
+++ b/packages/block-library/input/variations.js
@@ -117,6 +117,13 @@ const variations = [
 		description: __( 'A field for collecting a formatted time.', 'omniform' ),
 		attributes: { fieldType: 'time' },
 	},
+	{
+		name: 'input-color',
+		icon: { src: fieldInput },
+		title: __( 'Color', 'omniform' ),
+		description: __( 'A field for selecting a color.', 'omniform' ),
+		attributes: { fieldType: 'color' },
+	},
 ];
 
 variations.forEach( ( variation ) => {

--- a/phpunit/includes/BlockLibrary/Blocks/InputTest.php
+++ b/phpunit/includes/BlockLibrary/Blocks/InputTest.php
@@ -66,6 +66,20 @@ class InputTest extends FormBlockTestCase {
 	}
 
 	/**
+	 * Test get_validation_rules for color field type.
+	 */
+	public function test_get_validation_rules_color() {
+		$this->apply_block_context( 'omniform/fieldIsRequired', true );
+		$this->render_block_with_attributes( array( 'fieldType' => 'color' ) );
+
+		$rules = $this->block_instance->get_validation_rules();
+
+		$this->assertCount( 2, $rules );
+		$this->assertInstanceOf( 'OmniForm\Dependencies\Respect\Validation\Rules\NotEmpty', $rules[0] );
+		$this->assertInstanceOf( 'OmniForm\Dependencies\Respect\Validation\Rules\HexRgbColor', $rules[1] );
+	}
+
+	/**
 	 * Test get_control_value for various field types (checkbox, radio, date).
 	 */
 	public function test_get_control_value() {


### PR DESCRIPTION
Introduce a color picker field type, enhancing the Input block to support color selection. Update documentation to reflect the new input type and add validation rules for hex color.

Fixes #48