### PR TITLE
Add new props for margin and size control in edit components

### DIFF
--- a/packages/block-library/captcha/edit.js
+++ b/packages/block-library/captcha/edit.js
@@ -103,6 +103,8 @@ const Edit = ( {
 						value={ siteKey }
 						onChange={ setSiteKey }
 						type="password"
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 					/>
 
 					<TextControl
@@ -110,6 +112,8 @@ const Edit = ( {
 						value={ secretKey }
 						onChange={ setSecretKey }
 						type="password"
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 					/>
 
 					<ToggleGroupControl

--- a/packages/block-library/conditional-group/edit.js
+++ b/packages/block-library/conditional-group/edit.js
@@ -83,6 +83,8 @@ const Edit = ( {
 						value={ callback || '' }
 						onChange={ ( newValue ) => setAttributes( { callback: newValue } ) }
 						help={ __( 'The callback to determine if this block should be shown.', 'omniform' ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 					/>
 
 					<ToggleControl

--- a/packages/block-library/field/edit.js
+++ b/packages/block-library/field/edit.js
@@ -165,6 +165,8 @@ const Edit = ( {
 							value={ fieldLabel }
 							onChange={ updateLabel }
 							help={ __( 'Label for the form control.', 'omniform' ) }
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
 						/>
 					) }
 
@@ -178,6 +180,8 @@ const Edit = ( {
 							setAttributes( { fieldName: cleanFieldName( fieldName || fieldLabel ) } );
 						} }
 						help={ __( 'Name of the form control. Defaults to the label.', 'omniform' ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 					/>
 
 				</PanelBody>

--- a/packages/block-library/fieldset/edit.js
+++ b/packages/block-library/fieldset/edit.js
@@ -135,6 +135,8 @@ const Edit = ( {
 							setAttributes( { fieldName: cleanFieldName( fieldName || fieldLabel ) } );
 						} }
 						help={ __( 'Name of the fieldset. Defaults to the fieldset\'s label.', 'omniform' ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 					/>
 
 				</PanelBody>

--- a/packages/block-library/form/edit/create-form-modal/index.js
+++ b/packages/block-library/form/edit/create-form-modal/index.js
@@ -82,6 +82,8 @@ export default function CreateFormModal( { closeModal, onCreate } ) {
 					value={ title }
 					onChange={ setTitle }
 					required
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 				<BaseControl
 					label={ __( 'Type', 'omniform' ) }

--- a/packages/block-library/form/edit/inspector-controls.js
+++ b/packages/block-library/form/edit/inspector-controls.js
@@ -52,6 +52,8 @@ function StandardFormInspectorControls( { formId } ) {
 					value={ getSetting( 'form_title' ) || '' }
 					onChange={ ( newValue ) => setSetting( 'form_title', newValue ) }
 					help={ __( 'This name will not be visible to viewers and is only for identifying the form.', 'omniform' ) }
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 				<Button
 					variant="primary"
@@ -142,6 +144,8 @@ function StandaloneFormInspectorControls( { blockObject } ) {
 					value={ getSetting( 'form_title' ) || '' }
 					onChange={ ( newValue ) => setSetting( 'form_title', newValue ) }
 					help={ __( 'This name will not be visible to viewers and is only for identifying the form.', 'omniform' ) }
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 				<Text>
 					{ __( 'Want deeper insights into your form\'s performance?', 'omniform' ) }{ ' ' }

--- a/packages/block-library/form/edit/quick-start/index.js
+++ b/packages/block-library/form/edit/quick-start/index.js
@@ -449,6 +449,8 @@ const CaptchaSettingControls = ( { service } ) => {
 				value={ siteKey || '' }
 				onChange={ setSiteKey }
 				type="password"
+				__nextHasNoMarginBottom
+				__next40pxDefaultSize
 			/>
 
 			<TextControl
@@ -456,6 +458,8 @@ const CaptchaSettingControls = ( { service } ) => {
 				value={ secretKey || '' }
 				onChange={ setSecretKey }
 				type="password"
+				__nextHasNoMarginBottom
+				__next40pxDefaultSize
 			/>
 		</>
 	);

--- a/packages/components/form-settings/email-notifications.js
+++ b/packages/components/form-settings/email-notifications.js
@@ -62,6 +62,8 @@ export default function EmailNotificationSettings( {
 				onChange={ ( newValue ) => setSetting( 'notify_email_subject', newValue ) }
 				placeholder={ placeholder }
 				help={ __( 'Write a short headline for the notification.', 'omniform' ) }
+				__nextHasNoMarginBottom
+				__next40pxDefaultSize
 			/>
 		</PanelComponent>
 	);

--- a/packages/components/form-settings/submission-method.js
+++ b/packages/components/form-settings/submission-method.js
@@ -50,6 +50,8 @@ export default function SubmissionMethodSettings( {
 						value={ getSetting( 'submit_action' ) || '' }
 						onChange={ ( newValue ) => setSetting( 'submit_action', newValue ) }
 						help={ __( 'Enter the URL where the form data will be submitted.', 'omniform' ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 					/>
 					<SelectControl
 						label={ __( 'Submit Method', 'omniform' ) }


### PR DESCRIPTION
Introduce `__nextHasNoMarginBottom` and `__next40pxDefaultSize` props to various edit components for improved layout flexibility.

Fixes #62 