### PR TITLE
feat(fieldset): support required validation on choice group fieldsets

### DIFF
--- a/includes/BlockLibrary/Blocks/Input.php
+++ b/includes/BlockLibrary/Blocks/Input.php
@@ -62,6 +62,11 @@ class Input extends BaseControlBlock {
 			parent::get_extra_wrapper_attributes()
 		);
 
+		// Checkbox choice groups validate "at least one" in JS, not natively.
+		if ( $this->is_required_choice_checkbox() ) {
+			$extra_attributes['data-omniform-required-choice'] = true;
+		}
+
 		$attribute_input_type_mapping = array(
 			'placeholder' => array( 'text', 'email', 'url', 'number', 'month', 'password', 'search', 'tel', 'week', 'hidden', 'username-email' ),
 			'min'         => array( 'range' ),
@@ -107,8 +112,10 @@ class Input extends BaseControlBlock {
 	/**
 	 * Is the field required?
 	 *
-	 * Choice-group radios/checkboxes are never individually required; the
-	 * fieldset carries that rule. Lone checkboxes (e.g. consent) may be.
+	 * Choice-group radios carry the fieldset's required rule natively, so the
+	 * browser enforces "at least one". Checkbox choice groups validate via JS
+	 * instead, so they stay individually optional here. Lone checkboxes (e.g.
+	 * consent) may still be required on their own.
 	 */
 	public function is_required(): bool {
 		$is_choice_control = in_array(
@@ -118,10 +125,27 @@ class Input extends BaseControlBlock {
 		);
 
 		if ( $is_choice_control && $this->get_block_context( 'omniform/isChoiceGroup' ) ) {
-			return false;
+			return 'radio' === $this->get_block_attribute( 'fieldType' ) && parent::is_required();
 		}
 
 		return parent::is_required();
+	}
+
+	/**
+	 * Whether this is a checkbox inside a required choice group.
+	 *
+	 * Flags the input for the frontend "at least one" check.
+	 */
+	private function is_required_choice_checkbox(): bool {
+		if ( 'checkbox' !== $this->get_block_attribute( 'fieldType' ) ) {
+			return false;
+		}
+
+		if ( ! $this->get_block_context( 'omniform/isChoiceGroup' ) ) {
+			return false;
+		}
+
+		return (bool) ( $this->get_block_context( 'omniform/fieldGroupIsRequired' ) ?? false );
 	}
 
 	/**

--- a/packages/block-library/fieldset/edit.js
+++ b/packages/block-library/fieldset/edit.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useMemo } from '@wordpress/element';
 import {
 	BlockControls,
 	InspectorControls,
@@ -25,7 +25,11 @@ import { useMergeRefs } from '@wordpress/compose';
  * Internal dependencies
  */
 import { Required } from '../shared/icons';
-import { cleanFieldName, generateShortId } from '../shared/utils';
+import {
+	cleanFieldName,
+	choiceGroupType,
+	generateShortId,
+} from '../shared/utils';
 import {
 	useStandaloneFormSettings,
 	useStandardFormSettings,
@@ -40,7 +44,7 @@ const Edit = ( {
 } ) => {
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
-	const { formBlockObject } = useSelect(
+	const { formBlockObject, innerBlocks } = useSelect(
 		( select ) => {
 			const { getBlock, getBlockParents } = select( blockEditorStore );
 
@@ -57,10 +61,26 @@ const Edit = ( {
 					setAttributes: ( value ) =>
 						updateBlockAttributes( rootBlock, value ),
 				},
+				innerBlocks: getBlock( clientId )?.innerBlocks || [],
 			};
 		},
 		[ clientId, updateBlockAttributes ],
 	);
+
+	// Required on a fieldset only makes sense for a choice group (radios or
+	// checkboxes). For other fieldsets, required lives on individual fields.
+	const choiceType = useMemo(
+		() => choiceGroupType( innerBlocks ),
+		[ innerBlocks ],
+	);
+
+	// Drop a stale required flag when the fieldset stops being a choice
+	// group, since the toggle is then hidden and can't clear it.
+	useEffect( () => {
+		if ( ! choiceType && isRequired ) {
+			setAttributes( { isRequired: false } );
+		}
+	}, [ choiceType ] ); // eslint-disable-line react-hooks/exhaustive-deps -- isRequired intentionally read, only choiceType drives the clear
 
 	useEffect( () => {
 		if ( ! fieldName ) {
@@ -121,29 +141,39 @@ const Edit = ( {
 
 			<div { ...innerBlockProps } />
 
-			<BlockControls>
-				<ToolbarGroup>
-					<ToolbarButton
-						icon={ Required }
-						isActive={ isRequired }
-						label={ __( 'Required for submission', 'omniform' ) }
-						onClick={ toggleRequired }
-					/>
-				</ToolbarGroup>
-			</BlockControls>
+			{ choiceType && (
+				<BlockControls>
+					<ToolbarGroup>
+						<ToolbarButton
+							icon={ Required }
+							isActive={ isRequired }
+							label={ __(
+								'Required for submission',
+								'omniform',
+							) }
+							onClick={ toggleRequired }
+						/>
+					</ToolbarGroup>
+				</BlockControls>
+			) }
 
 			<InspectorControls>
 				<PanelBody title={ __( 'Fieldset Settings', 'omniform' ) }>
-					<ToggleControl
-						label={ __( 'Required for submission', 'omniform' ) }
-						checked={ isRequired }
-						onChange={ toggleRequired }
-						help={ __(
-							"Set default 'required' state for all fields in the group.",
-							'omniform',
-						) }
-						__nextHasNoMarginBottom
-					/>
+					{ choiceType && (
+						<ToggleControl
+							label={ __(
+								'Required for submission',
+								'omniform',
+							) }
+							checked={ isRequired }
+							onChange={ toggleRequired }
+							help={ __(
+								'At least one option must be selected.',
+								'omniform',
+							) }
+							__nextHasNoMarginBottom
+						/>
+					) }
 
 					<TextControl
 						label={ __( 'Name', 'omniform' ) }

--- a/packages/block-library/form/view.js
+++ b/packages/block-library/form/view.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
 
 ( function() {
@@ -19,6 +20,36 @@ import { applyFilters } from '@wordpress/hooks';
 			} );
 
 			return listElement;
+		};
+
+		// Whether every required checkbox choice group has at least one box
+		// checked. Triggers a validation message on the first empty group.
+		const hasRequiredCheckboxChoiceFilled = ( formEl ) => {
+			const groups = new Map();
+
+			formEl
+				.querySelectorAll( 'input[data-omniform-required-choice]' )
+				.forEach( ( input ) => {
+					const name = input.name || '';
+					if ( ! groups.has( name ) ) {
+						groups.set( name, [] );
+					}
+					groups.get( name ).push( input );
+				} );
+
+			for ( const inputs of groups.values() ) {
+				if ( ! inputs.some( ( input ) => input.checked ) ) {
+					const first = inputs[ 0 ];
+					first.setCustomValidity(
+						__( 'Please select at least one option.', 'omniform' ),
+					);
+					first.reportValidity();
+					first.setCustomValidity( '' );
+					return false;
+				}
+			}
+
+			return true;
 		};
 
 		// Add event listeners to all omniforms.
@@ -94,6 +125,12 @@ import { applyFilters } from '@wordpress/hooks';
 
 				const formResponseHandler = async ( event ) => {
 					event.preventDefault();
+
+					// Checkbox choice groups can't express "at least one"
+					// natively, so enforce it before submitting.
+					if ( ! hasRequiredCheckboxChoiceFilled( form ) ) {
+						return;
+					}
 
 					// Allow plugins to hook into the form submission.
 					const formElement = await applyFilters(

--- a/packages/block-library/shared/utils.js
+++ b/packages/block-library/shared/utils.js
@@ -40,3 +40,60 @@ export function cleanFieldName( string ) {
 			.replace( /(^-+)|(-+$)/g, '' )
 	);
 }
+
+/**
+ * Collects every omniform/input fieldType nested under the given blocks.
+ *
+ * Fields can nest inside core/columns, so the walk recurses into inner blocks.
+ *
+ * @param {Array} blocks Block list to inspect.
+ * @return {Array} fieldType strings; '' for fields without an input control.
+ */
+function collectFieldTypes( blocks ) {
+	const types = [];
+
+	if ( ! Array.isArray( blocks ) ) {
+		return types;
+	}
+
+	for ( const block of blocks ) {
+		if ( 'omniform/field' === block.name ) {
+			const input = ( block.innerBlocks || [] ).find(
+				( inner ) => 'omniform/input' === inner.name,
+			);
+			types.push( input ? input.attributes?.fieldType : '' );
+			continue;
+		}
+
+		if ( Array.isArray( block.innerBlocks ) && block.innerBlocks.length ) {
+			types.push( ...collectFieldTypes( block.innerBlocks ) );
+		}
+	}
+
+	return types;
+}
+
+/**
+ * Whether the blocks form a choice-only fieldset, and which kind.
+ *
+ * Returns 'radio' or 'checkbox' when every field is the same choice type;
+ * otherwise null (mixed, non-choice, or no fields).
+ *
+ * @param {Array} blocks Fieldset inner blocks.
+ * @return {string|null} The shared choice type, or null.
+ */
+export function choiceGroupType( blocks ) {
+	const types = collectFieldTypes( blocks );
+
+	if ( ! types.length ) {
+		return null;
+	}
+
+	const first = types[ 0 ];
+
+	if ( ! [ 'radio', 'checkbox' ].includes( first ) ) {
+		return null;
+	}
+
+	return types.every( ( type ) => type === first ) ? first : null;
+}

--- a/phpunit/unit/includes/BlockLibrary/Blocks/InputTest.php
+++ b/phpunit/unit/includes/BlockLibrary/Blocks/InputTest.php
@@ -207,4 +207,67 @@ class InputTest extends BaseTestCase {
 
 		$this->assertEquals( 'Test-Group[]', $result );
 	}
+
+	/**
+	 * A radio in a required choice group renders the native required attribute.
+	 */
+	public function testRenderBlockRadioChoiceGroupRequired() {
+		$this->wp_block_mock->context = array(
+			'omniform/fieldLabel'            => 'Test Label',
+			'omniform/fieldPath'             => 'Test-Group',
+			'omniform/isChoiceGroup'         => true,
+			'omniform/fieldGroupIsRequired'  => true,
+		);
+
+		$result = $this->block->render_block(
+			array( 'fieldType' => 'radio' ),
+			'',
+			$this->wp_block_mock
+		);
+
+		$this->assertStringContainsString( 'required="1"', $result );
+		$this->assertStringNotContainsString( 'data-omniform-required-choice', $result );
+	}
+
+	/**
+	 * A checkbox in a required choice group is flagged for JS validation, not
+	 * given a native required attribute.
+	 */
+	public function testRenderBlockCheckboxChoiceGroupRequired() {
+		$this->wp_block_mock->context = array(
+			'omniform/fieldLabel'            => 'Test Label',
+			'omniform/fieldPath'             => 'Test-Group',
+			'omniform/isChoiceGroup'         => true,
+			'omniform/fieldGroupIsRequired'  => true,
+		);
+
+		$result = $this->block->render_block(
+			array( 'fieldType' => 'checkbox' ),
+			'',
+			$this->wp_block_mock
+		);
+
+		$this->assertStringContainsString( 'data-omniform-required-choice="1"', $result );
+		$this->assertStringNotContainsString( ' required=', $result );
+	}
+
+	/**
+	 * A checkbox choice group that is not required carries no required flag.
+	 */
+	public function testRenderBlockCheckboxChoiceGroupNotRequired() {
+		$this->wp_block_mock->context = array(
+			'omniform/fieldLabel'    => 'Test Label',
+			'omniform/fieldPath'     => 'Test-Group',
+			'omniform/isChoiceGroup' => true,
+		);
+
+		$result = $this->block->render_block(
+			array( 'fieldType' => 'checkbox' ),
+			'',
+			$this->wp_block_mock
+		);
+
+		$this->assertStringNotContainsString( 'data-omniform-required-choice', $result );
+		$this->assertStringNotContainsString( ' required=', $result );
+	}
 }


### PR DESCRIPTION
## Summary
A fieldset can now be marked Required only when it is a pure choice group (every field is a radio, or every field is a checkbox). For other fieldsets the required toggle is hidden, since required there belongs on each individual field. The server-side validation pipeline is unchanged and still rejects empty required choice groups, so JS-disabled browsers stay covered.
Fixes #98

## Changes

### includes/BlockLibrary/Blocks/Input.php
**Before:**
```php
if ( $is_choice_control && $this->get_block_context( 'omniform/isChoiceGroup' ) ) {
    return false;
}
```
**After:**
```php
if ( $is_choice_control && $this->get_block_context( 'omniform/isChoiceGroup' ) ) {
    return 'radio' === $field_type && parent::is_required();
}
```
**Why:** Radios in a required choice group now render the native `required` attribute so the browser enforces "at least one". Checkboxes stay false because native `required` on a checkbox means "this one must be checked", not "one of the group".

A `data-omniform-required-choice` attribute is added to checkboxes in a required choice group so the frontend guard can find and validate them.

### packages/block-library/shared/utils.js
**Before:**
No helper to detect a pure choice group.
**After:**
```js
export function choiceGroupType( blocks ) {
    const types = collectFieldTypes( blocks );
    if ( ! types.length ) return null;
    const first = types[ 0 ];
    if ( ! [ 'radio', 'checkbox' ].includes( first ) ) return null;
    return types.every( ( type ) => type === first ) ? first : null;
}
```
**Why:** The editor needs to know whether a fieldset is a pure radio or checkbox group before showing the required toggle. The walk recurses through `core/columns` (the address variation nests fields there), matching the PHP `BlockFormSchemaParser::choice_group_type`.

### packages/block-library/fieldset/edit.js
**Before:**
The Required toolbar button and inspector ToggleControl were always shown.
**After:**
```js
const choiceType = useMemo( () => choiceGroupType( innerBlocks ), [ innerBlocks ] );
// ...
{ choiceType && ( <BlockControls> ... </BlockControls> ) }
{ choiceType && ( <ToggleControl ... help={ __( 'At least one option must be selected.', 'omniform' ) } /> ) }
```
**Why:** The toggle now appears only for choice groups. A `useEffect` clears a stale `isRequired` flag when a fieldset stops being a choice group, since the toggle is then hidden and cannot clear it manually.

### packages/block-library/form/view.js
**Before:**
The submit handler went straight to `apiFetch` after `event.preventDefault()`.
**After:**
```js
if ( ! hasRequiredCheckboxChoiceFilled( form ) ) {
    return;
}
```
**Why:** Checkbox groups cannot express "at least one" in HTML, so the guard groups inputs by `name`, finds the first group with no box checked, calls `setCustomValidity` + `reportValidity` on its first input, and blocks submission. Radios never reach here because native `required` stops the submit event first.

### phpunit/unit/includes/BlockLibrary/Blocks/InputTest.php
Added three cases: a radio in a required choice group renders `required`, a checkbox in a required choice group renders `data-omniform-required-choice` and not `required`, and a non-required checkbox group carries no flag.

## Testing
**Test 1: Radio group, required, empty submit**
1. Create a form, insert a Multiple Choice (radios) fieldset, add 2-3 options.
2. Select the fieldset, enable Required in the toolbar (also visible in Inspector with help "At least one option must be selected.").
3. Save, view on the front end, leave all radios unchecked, submit.
Result: the browser shows its native "please select one of these options" message and the form does not submit.

**Test 2: Checkbox group, required, empty submit**
1. Insert a fieldset, add 2-3 checkbox fields, mark it Required.
2. View on the front end, leave all checkboxes unchecked, submit.
Result: a "Please select at least one option." message appears on the first checkbox and the form does not submit.

**Test 3: Checkbox group, required, with selection**
1. Same form as Test 2, check at least one box, submit.
Result: submission proceeds.

**Test 4: Non-choice fieldset hides the toggle**
1. Insert a fieldset and add text input fields (e.g. the Address variation).
2. Select the fieldset.
Result: the Required toolbar button and the inspector ToggleControl are not present. Required toggles on individual fields still work.

**Test 5: JS-disabled browser still rejects**
1. Disable JavaScript, load a form with a required checkbox choice group, submit empty.
Result: the frontend guard does not run, the server rejects the submission with a validation error for the group (existing server-side behavior).

Automated checks run before this PR: the three new InputTest cases pass (13 total in InputTest, 19 assertions), and `npm run lint:css` is clean. `npm run lint:js` shows only pre-existing errors in `packages/dashboard/`, none in the files changed here.

## Screenshot
<img width="1014" height="735" alt="image" src="https://github.com/user-attachments/assets/8470dd87-d809-4ade-b015-15fe90ee12f2" />
