### PR TITLE
fix(OAuth): validate API responses in ApiClient request()

### DIFF
--- a/includes/OAuth/ApiClient.php
+++ b/includes/OAuth/ApiClient.php
@@ -115,7 +115,23 @@ class ApiClient {
 			return new \WP_Error( 'invalid_method', __( 'Invalid HTTP method.', 'omniform' ) );
 		}
 
-		return $response;
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$response_code = wp_remote_retrieve_response_code( $response );
+
+		if ( $response_code < 200 || $response_code >= 300 ) {
+			return new \WP_Error( 'api_error', __( 'API request failed.', 'omniform' ), array( 'status' => $response_code ) );
+		}
+
+		$decoded_body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $decoded_body ) ) {
+			return new \WP_Error( 'invalid_json', __( 'Invalid JSON response.', 'omniform' ) );
+		}
+
+		return $decoded_body;
 	}
 
 	/**

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -34,6 +34,9 @@ if ( ! class_exists( 'WP_Block', false ) ) {
 	}
 }
 
+// Load test doubles for WordPress core classes (core is not bootstrapped).
+require_once __DIR__ . '/doubles/WP_Error.php';
+
 // Initialize WP_Mock.
 WP_Mock::bootstrap();
 

--- a/phpunit/doubles/WP_Error.php
+++ b/phpunit/doubles/WP_Error.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Test double for WordPress WP_Error.
+ *
+ * WordPress core is not bootstrapped for unit tests, so a minimal WP_Error
+ * is provided here for code that constructs or asserts against WP_Error.
+ *
+ * @package OmniForm
+ */
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
+
+if ( ! class_exists( 'WP_Error', false ) ) {
+	/**
+	 * Test double for WordPress WP_Error.
+	 */
+	class WP_Error {
+		/**
+		 * Error code.
+		 *
+		 * @var string|int
+		 */
+		private $code;
+
+		/**
+		 * Error message.
+		 *
+		 * @var string
+		 */
+		private $message;
+
+		/**
+		 * Error data.
+		 *
+		 * @var mixed
+		 */
+		private $data;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param string|int $code    Error code.
+		 * @param string     $message Error message.
+		 * @param mixed      $data    Optional error data.
+		 */
+		public function __construct( $code = '', $message = '', $data = '' ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+
+		/**
+		 * Get the error code.
+		 *
+		 * @return string|int
+		 */
+		public function get_error_code() {
+			return $this->code;
+		}
+
+		/**
+		 * Get the error message.
+		 *
+		 * @param string|int $code Optional error code. Unused; this double holds a single error.
+		 * @return string
+		 */
+		public function get_error_message( $code = '' ) {
+			return $this->message;
+		}
+
+		/**
+		 * Get the error data.
+		 *
+		 * @param string|int $code Optional error code. Unused; this double holds a single error.
+		 * @return mixed
+		 */
+		public function get_error_data( $code = '' ) {
+			return $this->data;
+		}
+	}
+}

--- a/phpunit/unit/OAuth/ApiClientTest.php
+++ b/phpunit/unit/OAuth/ApiClientTest.php
@@ -81,33 +81,61 @@ class ApiClientTest extends BaseTestCase {
 	}
 
 	/**
-	 * Test get with valid token.
+	 * Test get with valid token returns the decoded response body.
 	 */
 	public function testGetWithValidToken() {
 		$this->token_storage->shouldReceive( 'is_expired' )->andReturn( false );
 		$this->token_storage->shouldReceive( 'get_access_token' )->andReturn( 'valid_token' );
 
+		$response = array( 'body' => '{"data": "test"}' );
+
 		WP_Mock::userFunction( 'wp_remote_get' )
-			->andReturn( array( 'body' => '{"data": "test"}' ) );
+			->andReturn( $response );
+		WP_Mock::userFunction( 'is_wp_error' )
+			->with( $response )
+			->once()
+			->andReturn( false );
+		WP_Mock::userFunction( 'wp_remote_retrieve_response_code' )
+			->with( $response )
+			->once()
+			->andReturn( 200 );
+		WP_Mock::userFunction( 'wp_remote_retrieve_body' )
+			->with( $response )
+			->once()
+			->andReturn( '{"data": "test"}' );
 
 		$result = $this->api_client->get( '/test' );
 
-		$this->assertEquals( array( 'body' => '{"data": "test"}' ), $result );
+		$this->assertEquals( array( 'data' => 'test' ), $result );
 	}
 
 	/**
-	 * Test post with valid token.
+	 * Test post with valid token returns the decoded response body.
 	 */
 	public function testPostWithValidToken() {
 		$this->token_storage->shouldReceive( 'is_expired' )->andReturn( false );
 		$this->token_storage->shouldReceive( 'get_access_token' )->andReturn( 'valid_token' );
 
+		$response = array( 'body' => '{"success": true}' );
+
 		WP_Mock::userFunction( 'wp_remote_post' )
-			->andReturn( array( 'body' => '{"success": true}' ) );
+			->andReturn( $response );
+		WP_Mock::userFunction( 'is_wp_error' )
+			->with( $response )
+			->once()
+			->andReturn( false );
+		WP_Mock::userFunction( 'wp_remote_retrieve_response_code' )
+			->with( $response )
+			->once()
+			->andReturn( 200 );
+		WP_Mock::userFunction( 'wp_remote_retrieve_body' )
+			->with( $response )
+			->once()
+			->andReturn( '{"success": true}' );
 
 		$result = $this->api_client->post( '/test' );
 
-		$this->assertEquals( array( 'body' => '{"success": true}' ), $result );
+		$this->assertEquals( array( 'success' => true ), $result );
 	}
 
 	/**
@@ -118,38 +146,50 @@ class ApiClientTest extends BaseTestCase {
 		$this->oauth_manager->shouldReceive( 'refresh_access_token' )->andReturn( true );
 		$this->token_storage->shouldReceive( 'get_access_token' )->andReturn( 'new_token' );
 
+		$response = array( 'body' => '{"data": "refreshed"}' );
+
 		WP_Mock::userFunction( 'wp_remote_get' )
-			->andReturn( array( 'body' => '{"data": "refreshed"}' ) );
+			->andReturn( $response );
+		WP_Mock::userFunction( 'is_wp_error' )
+			->with( $response )
+			->once()
+			->andReturn( false );
+		WP_Mock::userFunction( 'wp_remote_retrieve_response_code' )
+			->with( $response )
+			->once()
+			->andReturn( 200 );
+		WP_Mock::userFunction( 'wp_remote_retrieve_body' )
+			->with( $response )
+			->once()
+			->andReturn( '{"data": "refreshed"}' );
 
 		$result = $this->api_client->get( '/test' );
 
-		$this->assertEquals( array( 'body' => '{"data": "refreshed"}' ), $result );
+		$this->assertEquals( array( 'data' => 'refreshed' ), $result );
 	}
 
 	/**
-	 * Test post with expired token and failed refresh.
+	 * Test post with expired token and failed refresh returns a WP_Error.
 	 */
 	public function testPostWithExpiredTokenAndFailedRefresh() {
 		$this->token_storage->shouldReceive( 'is_expired' )->andReturn( true );
 		$this->oauth_manager->shouldReceive( 'refresh_access_token' )->andReturn( false );
 		$this->token_storage->shouldReceive( 'clear_tokens' )->once();
 
-		Mockery::mock( 'overload:WP_Error' )
-			->shouldReceive( 'get_error_code' )
-			->andReturn( 'oauth_no_token' );
-
 		$result = $this->api_client->post( '/test' );
 
-		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertEquals( 'oauth_no_token', $result->get_error_code() );
 	}
 
 	/**
-	 * Test get with additional args.
+	 * Test get with additional args passes them through to the request.
 	 */
 	public function testGetWithAdditionalArgs() {
 		$this->token_storage->shouldReceive( 'is_expired' )->andReturn( false );
 		$this->token_storage->shouldReceive( 'get_access_token' )->andReturn( 'valid_token' );
+
+		$response = array( 'body' => '{"data": "with_args"}' );
 
 		WP_Mock::userFunction( 'wp_remote_get' )
 			->with(
@@ -162,10 +202,100 @@ class ApiClientTest extends BaseTestCase {
 					'timeout' => 30,
 				)
 			)
-			->andReturn( array( 'body' => '{"data": "with_args"}' ) );
+			->andReturn( $response );
+		WP_Mock::userFunction( 'is_wp_error' )
+			->with( $response )
+			->once()
+			->andReturn( false );
+		WP_Mock::userFunction( 'wp_remote_retrieve_response_code' )
+			->with( $response )
+			->once()
+			->andReturn( 200 );
+		WP_Mock::userFunction( 'wp_remote_retrieve_body' )
+			->with( $response )
+			->once()
+			->andReturn( '{"data": "with_args"}' );
 
 		$result = $this->api_client->get( '/test', array( 'timeout' => 30 ) );
 
-		$this->assertEquals( array( 'body' => '{"data": "with_args"}' ), $result );
+		$this->assertEquals( array( 'data' => 'with_args' ), $result );
+	}
+
+	/**
+	 * Test get returns the WP_Error untouched when the transport fails.
+	 */
+	public function testGetReturnsWpErrorOnTransportFailure() {
+		$this->token_storage->shouldReceive( 'is_expired' )->andReturn( false );
+		$this->token_storage->shouldReceive( 'get_access_token' )->andReturn( 'valid_token' );
+
+		$error = new \WP_Error( 'http_failure', 'Request failed.' );
+
+		WP_Mock::userFunction( 'wp_remote_get' )
+			->andReturn( $error );
+		WP_Mock::userFunction( 'is_wp_error' )
+			->with( $error )
+			->once()
+			->andReturn( true );
+
+		$result = $this->api_client->get( '/test' );
+
+		$this->assertSame( $error, $result );
+	}
+
+	/**
+	 * Test get returns a WP_Error with the status code for a non-2xx response.
+	 */
+	public function testGetWithNon2xxStatusCode() {
+		$this->token_storage->shouldReceive( 'is_expired' )->andReturn( false );
+		$this->token_storage->shouldReceive( 'get_access_token' )->andReturn( 'valid_token' );
+
+		$response = array( 'response' => array( 'code' => 500 ) );
+
+		WP_Mock::userFunction( 'wp_remote_get' )
+			->andReturn( $response );
+		WP_Mock::userFunction( 'is_wp_error' )
+			->with( $response )
+			->once()
+			->andReturn( false );
+		WP_Mock::userFunction( 'wp_remote_retrieve_response_code' )
+			->with( $response )
+			->once()
+			->andReturn( 500 );
+
+		$result = $this->api_client->get( '/test' );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertEquals( 'api_error', $result->get_error_code() );
+		$this->assertEquals( array( 'status' => 500 ), $result->get_error_data() );
+	}
+
+	/**
+	 * Test get returns a WP_Error when the response body is not valid JSON.
+	 */
+	public function testGetWithInvalidJson() {
+		$this->token_storage->shouldReceive( 'is_expired' )->andReturn( false );
+		$this->token_storage->shouldReceive( 'get_access_token' )->andReturn( 'valid_token' );
+
+		$response = array( 'body' => 'not json' );
+
+		WP_Mock::userFunction( 'wp_remote_get' )
+			->andReturn( $response );
+		WP_Mock::userFunction( 'is_wp_error' )
+			->with( $response )
+			->once()
+			->andReturn( false );
+		WP_Mock::userFunction( 'wp_remote_retrieve_response_code' )
+			->with( $response )
+			->once()
+			->andReturn( 200 );
+		WP_Mock::userFunction( 'wp_remote_retrieve_body' )
+			->with( $response )
+			->once()
+			->andReturn( 'not json' );
+
+		$result = $this->api_client->get( '/test' );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertEquals( 'invalid_json', $result->get_error_code() );
 	}
 }


### PR DESCRIPTION
## Summary

`ApiClient::request()` returned the raw `wp_remote_get()`/`wp_remote_post()` result without checking transport errors, HTTP status, or JSON validity. Malformed or failed responses passed straight through to callers.

This adds validation to `request()` before it returns: transport `WP_Error` passes through untouched, any non-2xx status returns an `api_error` `WP_Error` carrying the status code, and invalid or non-array JSON returns an `invalid_json` `WP_Error`. On success the decoded array is returned.

Fixes #80

## Changes

### includes/OAuth/ApiClient.php

**Before:**
```php
if ( 'GET' === $method ) {
    return wp_remote_get( $url, $request_args );
}

if ( 'POST' === $method ) {
    return wp_remote_post( $url, $request_args );
}
```

**After:**
```php
if ( 'GET' === $method ) {
    $response = wp_remote_get( $url, $request_args );
} elseif ( 'POST' === $method ) {
    $response = wp_remote_post( $url, $request_args );
} else {
    return new \WP_Error( 'invalid_method', __( 'Invalid HTTP method.', 'omniform' ) );
}

if ( is_wp_error( $response ) ) {
    return $response;
}

$response_code = wp_remote_retrieve_response_code( $response );

if ( $response_code < 200 || $response_code >= 300 ) {
    return new \WP_Error( 'api_error', __( 'API request failed.', 'omniform' ), array( 'status' => $response_code ) );
}

$decoded_body = json_decode( wp_remote_retrieve_body( $response ), true );

if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $decoded_body ) ) {
    return new \WP_Error( 'invalid_json', __( 'Invalid JSON response.', 'omniform' ) );
}

return $decoded_body;
```

**Why:** Validates the response in the one place all API calls route through, so every caller gets either a usable decoded array or a descriptive `WP_Error` instead of raw, unvalidated output. Matches the `is_wp_error()` + `json_decode( wp_remote_retrieve_body(), true )` idiom already used elsewhere in the plugin (`OAuthManager`, captcha rules).

`healthcheck()` is unchanged and bypasses `request()`; its caller already validates.

### phpunit/bootstrap.php + phpunit/doubles/WP_Error.php

Added a minimal `WP_Error` test double (loaded in the bootstrap) so the error-path tests can assert real error codes and data without WordPress core.

### phpunit/unit/OAuth/ApiClientTest.php

Updated the success-path tests to the decoded-array contract and added tests for the new branches: transport `WP_Error` pass-through, non-2xx `api_error` with status data, and `invalid_json`.

## Testing

**Test 1: Unit tests (automated)**

```
composer test
```
Result: full suite green. `ApiClientTest` covers all four `request()` branches plus the token refresh path (9 tests).

**Test 2: Lint (automated)**

```
composer lint
```
Result: no new violations vs master.

Environment: PHP 8.2, WordPress (wp-env, Docker), plugin dev dependencies installed.

There is no UI surface that calls `get()`/`post()` today (`OAuthConnectionUI::render()` is registered in the container but not wired to a menu page callback), so manual UI testing is not applicable. The untouched `healthcheck()` path is exercised by its existing caller and is unchanged.