### PR TITLE
feat(webhook): add signed webhook endpoint for async API events

### DIFF
--- a/includes/OAuth/OAuthManager.php
+++ b/includes/OAuth/OAuthManager.php
@@ -117,6 +117,10 @@ class OAuthManager {
 		if ( $tokens ) {
 			$this->token_storage->set_access_token( $tokens['access_token'], $tokens['expires_in'] );
 			$this->token_storage->set_refresh_token( $tokens['refresh_token'] );
+
+			if ( ! empty( $tokens['webhook_secret'] ) && is_string( $tokens['webhook_secret'] ) ) {
+				$this->token_storage->set_webhook_secret( $tokens['webhook_secret'] );
+			}
 		} else {
 			wp_die( esc_html__( 'Failed to exchange code for tokens.', 'omniform' ) );
 			if ( defined( 'PHPUNIT_TESTING' ) && constant( 'PHPUNIT_TESTING' ) ) {
@@ -167,6 +171,9 @@ class OAuthManager {
 			$this->token_storage->set_access_token( $body['access_token'], $body['expires_in'] );
 			if ( isset( $body['refresh_token'] ) ) {
 				$this->token_storage->set_refresh_token( $body['refresh_token'] );
+			}
+			if ( ! empty( $body['webhook_secret'] ) && is_string( $body['webhook_secret'] ) ) {
+				$this->token_storage->set_webhook_secret( $body['webhook_secret'] );
 			}
 			return true;
 		}

--- a/includes/OAuth/TokenStorage.php
+++ b/includes/OAuth/TokenStorage.php
@@ -32,6 +32,11 @@ class TokenStorage {
 	const CLIENT_ID_KEY = 'omniform_client_id';
 
 	/**
+	 * Option key for the webhook signing secret.
+	 */
+	const WEBHOOK_SECRET_KEY = 'omniform_webhook_secret';
+
+	/**
 	 * Get the access token.
 	 *
 	 * @return string|null
@@ -104,7 +109,30 @@ class TokenStorage {
 	}
 
 	/**
-	 * Clear all tokens and client ID.
+	 * Get the webhook signing secret.
+	 *
+	 * @return string|null
+	 */
+	public function get_webhook_secret(): ?string {
+		return get_option( self::WEBHOOK_SECRET_KEY, null );
+	}
+
+	/**
+	 * Set the webhook signing secret.
+	 *
+	 * Stored with autoload disabled so the secret is not loaded into the
+	 * all-options cache on every request.
+	 *
+	 * @param string $secret The webhook secret.
+	 *
+	 * @return void
+	 */
+	public function set_webhook_secret( string $secret ): void {
+		update_option( self::WEBHOOK_SECRET_KEY, $secret, false );
+	}
+
+	/**
+	 * Clear all tokens, client ID, and webhook secret.
 	 *
 	 * @return void
 	 */
@@ -113,5 +141,6 @@ class TokenStorage {
 		delete_option( self::REFRESH_TOKEN_KEY );
 		delete_option( self::TOKEN_EXPIRES_KEY );
 		delete_option( self::CLIENT_ID_KEY );
+		delete_option( self::WEBHOOK_SECRET_KEY );
 	}
 }

--- a/includes/Webhook/WebhookController.php
+++ b/includes/Webhook/WebhookController.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * The WebhookController class.
+ *
+ * @package OmniForm
+ */
+
+namespace OmniForm\Webhook;
+
+use OmniForm\OAuth\TokenStorage;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * The WebhookController class.
+ *
+ * Registers the inbound webhook endpoint that the OmniForm API calls
+ * to deliver async events. Requests are authenticated by an HMAC-SHA256
+ * signature over the raw request body, not by WordPress nonces.
+ */
+class WebhookController extends WP_REST_Controller {
+
+	/**
+	 * The TokenStorage instance.
+	 *
+	 * @var TokenStorage
+	 */
+	protected $token_storage;
+
+	/**
+	 * The namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'omniform/v1';
+
+	/**
+	 * The rest base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'webhook';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param TokenStorage $token_storage The TokenStorage instance.
+	 */
+	public function __construct( TokenStorage $token_storage ) {
+		$this->token_storage = $token_storage;
+	}
+
+	/**
+	 * Registers the routes for the objects of the controller.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'handle_webhook' ),
+				'permission_callback' => array( $this, 'permissions_check' ),
+			)
+		);
+	}
+
+	/**
+	 * Checks if a given request has access to the webhook.
+	 *
+	 * The endpoint is public: the OmniForm API cannot send a WordPress
+	 * nonce, so authentication happens via the HMAC signature in
+	 * handle_webhook() instead of a capability check here.
+	 *
+	 * @return true True. Signature verification gates the request.
+	 */
+	public function permissions_check() {
+		return true;
+	}
+
+	/**
+	 * Handles an inbound webhook from the OmniForm API.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_Error|array WP_Error on failure, or the received response.
+	 */
+	public function handle_webhook( WP_REST_Request $request ) {
+		$raw_body = $request->get_body();
+		$secret   = $this->token_storage->get_webhook_secret();
+
+		if ( ! $secret ) {
+			return new WP_Error(
+				'omniform_webhook_not_configured',
+				__( 'Webhook secret not configured.', 'omniform' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$signature = $request->get_header( 'x_omniform_signature' );
+
+		if ( ! $signature ) {
+			return new WP_Error(
+				'omniform_webhook_missing_signature',
+				__( 'Missing webhook signature.', 'omniform' ),
+				array( 'status' => 401 )
+			);
+		}
+
+		$computed = hash_hmac( 'sha256', $raw_body, $secret );
+
+		if ( ! hash_equals( $computed, $signature ) ) {
+			return new WP_Error(
+				'omniform_webhook_invalid_signature',
+				__( 'Invalid webhook signature.', 'omniform' ),
+				array( 'status' => 401 )
+			);
+		}
+
+		$payload = json_decode( $raw_body, true );
+
+		if ( ! is_array( $payload ) || empty( $payload['type'] ) || ! is_string( $payload['type'] ) ) {
+			return new WP_Error(
+				'omniform_webhook_invalid_payload',
+				__( 'Invalid webhook payload.', 'omniform' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		do_action( 'omniform_webhook_received', $payload );
+
+		return array( 'received' => true );
+	}
+}

--- a/includes/Webhook/WebhookServiceProvider.php
+++ b/includes/Webhook/WebhookServiceProvider.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * The WebhookServiceProvider class.
+ *
+ * @package OmniForm
+ */
+
+namespace OmniForm\Webhook;
+
+use OmniForm\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider;
+use OmniForm\Dependencies\League\Container\ServiceProvider\BootableServiceProviderInterface;
+use OmniForm\OAuth\TokenStorage;
+
+/**
+ * The WebhookServiceProvider class.
+ */
+class WebhookServiceProvider extends AbstractServiceProvider implements BootableServiceProviderInterface {
+	/**
+	 * Get the services provided by the provider.
+	 *
+	 * @param string $id The service to check.
+	 *
+	 * @return bool
+	 */
+	public function provides( string $id ): bool {
+		$services = array(
+			WebhookController::class,
+		);
+
+		return in_array( $id, $services, true );
+	}
+
+	/**
+	 * Register any application services.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		$this->getContainer()
+			->add( WebhookController::class )
+			->addArgument( TokenStorage::class );
+	}
+
+	/**
+	 * Bootstrap any application services by hooking into WordPress with actions/filters.
+	 *
+	 * @return void
+	 */
+	public function boot(): void {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Register the REST API routes.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		$this->getContainer()->get( WebhookController::class )->register_routes();
+	}
+}

--- a/omniform.php
+++ b/omniform.php
@@ -54,6 +54,7 @@ omniform()->register( new \OmniForm\FormTypes\FormTypesServiceProvider() );
 omniform()->register( new \OmniForm\Analytics\AnalyticsServiceProvider() );
 omniform()->register( new \OmniForm\BlockLibrary\BlockLibraryServiceProvider() );
 omniform()->register( new \OmniForm\OAuth\OAuthServiceProvider() );
+omniform()->register( new \OmniForm\Webhook\WebhookServiceProvider() );
 
 register_activation_hook( __FILE__, array( omniform(), 'activation' ) );
 register_deactivation_hook( __FILE__, array( omniform(), 'deactivation' ) );

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -34,6 +34,144 @@ if ( ! class_exists( 'WP_Block', false ) ) {
 	}
 }
 
+/*
+ * Minimal REST doubles for unit tests (WordPress core is not bootstrapped).
+ */
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound,Generic.Files.OneObjectStructurePerFile.MultipleFound
+if ( ! class_exists( 'WP_REST_Controller', false ) ) {
+	/**
+	 * Test double for WordPress WP_REST_Controller.
+	 */
+	class WP_REST_Controller {
+		/**
+		 * The namespace.
+		 *
+		 * @var string
+		 */
+		protected $namespace;
+
+		/**
+		 * The rest base.
+		 *
+		 * @var string
+		 */
+		protected $rest_base;
+
+		/**
+		 * Registers the routes for the objects of the controller.
+		 */
+		public function register_routes() {}
+	}
+}
+
+if ( ! class_exists( 'WP_REST_Server', false ) ) {
+	/**
+	 * Test double for WordPress WP_REST_Server.
+	 */
+	class WP_REST_Server {
+		const READABLE   = 'GET';
+		const CREATABLE  = 'POST';
+		const EDITABLE   = 'POST, PUT, PATCH';
+		const DELETABLE  = 'DELETE';
+		const ALLMETHODS = 'GET, POST, PUT, PATCH, DELETE';
+	}
+}
+
+if ( ! class_exists( 'WP_REST_Request', false ) ) {
+	/**
+	 * Test double for WordPress WP_REST_Request.
+	 */
+	class WP_REST_Request {
+		/**
+		 * Get the request body.
+		 *
+		 * @return string
+		 */
+		public function get_body() {
+			return '';
+		}
+
+		/**
+		 * Get a header value.
+		 *
+		 * @param string $header Header name.
+		 * @return string|null
+		 */
+		public function get_header( $header ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			return null;
+		}
+	}
+}
+
+if ( ! class_exists( 'WP_Error', false ) ) {
+	/**
+	 * Test double for WordPress WP_Error.
+	 */
+	class WP_Error {
+		/**
+		 * Error code.
+		 *
+		 * @var string
+		 */
+		private $code;
+
+		/**
+		 * Error message.
+		 *
+		 * @var string
+		 */
+		private $message;
+
+		/**
+		 * Error data.
+		 *
+		 * @var mixed
+		 */
+		private $data;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param string|int $code    Error code.
+		 * @param string     $message Error message.
+		 * @param mixed      $data    Error data.
+		 */
+		public function __construct( $code = '', $message = '', $data = '' ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+
+		/**
+		 * Get the error code.
+		 *
+		 * @return string|int
+		 */
+		public function get_error_code() {
+			return $this->code;
+		}
+
+		/**
+		 * Get the error data.
+		 *
+		 * @return mixed
+		 */
+		public function get_error_data() {
+			return $this->data;
+		}
+
+		/**
+		 * Get the error message.
+		 *
+		 * @return string
+		 */
+		public function get_error_message() {
+			return $this->message;
+		}
+	}
+}
+// phpcs:enable
+
 // Initialize WP_Mock.
 WP_Mock::bootstrap();
 

--- a/phpunit/unit/OAuth/ApiClientTest.php
+++ b/phpunit/unit/OAuth/ApiClientTest.php
@@ -134,10 +134,6 @@ class ApiClientTest extends BaseTestCase {
 		$this->oauth_manager->shouldReceive( 'refresh_access_token' )->andReturn( false );
 		$this->token_storage->shouldReceive( 'clear_tokens' )->once();
 
-		Mockery::mock( 'overload:WP_Error' )
-			->shouldReceive( 'get_error_code' )
-			->andReturn( 'oauth_no_token' );
-
 		$result = $this->api_client->post( '/test' );
 
 		$this->assertInstanceOf( 'WP_Error', $result );

--- a/phpunit/unit/OAuth/OAuthManagerTest.php
+++ b/phpunit/unit/OAuth/OAuthManagerTest.php
@@ -138,9 +138,10 @@ class OAuthManagerTest extends BaseTestCase {
 				array(
 					'body' => json_encode( // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
 						array(
-							'access_token'  => 'new_access_token',
-							'refresh_token' => 'new_refresh_token',
-							'expires_in'    => 3600,
+							'access_token'   => 'new_access_token',
+							'refresh_token'  => 'new_refresh_token',
+							'expires_in'     => 3600,
+							'webhook_secret' => 'wh_secret',
 						)
 					),
 				)
@@ -149,9 +150,10 @@ class OAuthManagerTest extends BaseTestCase {
 			->andReturn(
 				json_encode( // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
 					array(
-						'access_token'  => 'new_access_token',
-						'refresh_token' => 'new_refresh_token',
-						'expires_in'    => 3600,
+						'access_token'   => 'new_access_token',
+						'refresh_token'  => 'new_refresh_token',
+						'expires_in'     => 3600,
+						'webhook_secret' => 'wh_secret',
 					)
 				)
 			);
@@ -163,6 +165,9 @@ class OAuthManagerTest extends BaseTestCase {
 			->once();
 		$this->token_storage->shouldReceive( 'set_refresh_token' )
 			->with( 'new_refresh_token' )
+			->once();
+		$this->token_storage->shouldReceive( 'set_webhook_secret' )
+			->with( 'wh_secret' )
 			->once();
 
 		WP_Mock::userFunction( 'admin_url' )
@@ -259,9 +264,10 @@ class OAuthManagerTest extends BaseTestCase {
 				array(
 					'body' => json_encode( // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
 						array(
-							'access_token'  => 'new_access_token',
-							'expires_in'    => 3600,
-							'refresh_token' => 'new_refresh_token',
+							'access_token'   => 'new_access_token',
+							'expires_in'     => 3600,
+							'refresh_token'  => 'new_refresh_token',
+							'webhook_secret' => 'wh_secret',
 						)
 					),
 				)
@@ -270,9 +276,10 @@ class OAuthManagerTest extends BaseTestCase {
 			->andReturn(
 				json_encode( // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
 					array(
-						'access_token'  => 'new_access_token',
-						'expires_in'    => 3600,
-						'refresh_token' => 'new_refresh_token',
+						'access_token'   => 'new_access_token',
+						'expires_in'     => 3600,
+						'refresh_token'  => 'new_refresh_token',
+						'webhook_secret' => 'wh_secret',
 					)
 				)
 			);
@@ -284,6 +291,9 @@ class OAuthManagerTest extends BaseTestCase {
 			->once();
 		$this->token_storage->shouldReceive( 'set_refresh_token' )
 			->with( 'new_refresh_token' )
+			->once();
+		$this->token_storage->shouldReceive( 'set_webhook_secret' )
+			->with( 'wh_secret' )
 			->once();
 
 		$result = $this->oauth_manager->refresh_access_token();
@@ -318,5 +328,48 @@ class OAuthManagerTest extends BaseTestCase {
 		$result = $this->oauth_manager->refresh_access_token();
 
 		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test refresh_access_token ignores an empty webhook secret.
+	 */
+	public function testRefreshAccessTokenIgnoresEmptyWebhookSecret() {
+		$this->token_storage->shouldReceive( 'get_refresh_token' )->andReturn( 'refresh_token' );
+		$this->token_storage->shouldReceive( 'get_client_id' )->andReturn( 'client_id' );
+
+		WP_Mock::userFunction( 'wp_remote_post' )
+			->andReturn(
+				array(
+					'body' => json_encode( // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
+						array(
+							'access_token'   => 'new_access_token',
+							'expires_in'     => 3600,
+							'refresh_token'  => 'new_refresh_token',
+							'webhook_secret' => '',
+						)
+					),
+				)
+			);
+		WP_Mock::userFunction( 'wp_remote_retrieve_body' )
+			->andReturn(
+				json_encode( // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
+					array(
+						'access_token'   => 'new_access_token',
+						'expires_in'     => 3600,
+						'refresh_token'  => 'new_refresh_token',
+						'webhook_secret' => '',
+					)
+				)
+			);
+		WP_Mock::userFunction( 'is_wp_error' )
+			->andReturn( false );
+
+		$this->token_storage->shouldReceive( 'set_access_token' )->once();
+		$this->token_storage->shouldReceive( 'set_refresh_token' )->once();
+		$this->token_storage->shouldNotReceive( 'set_webhook_secret' );
+
+		$result = $this->oauth_manager->refresh_access_token();
+
+		$this->assertTrue( $result );
 	}
 }

--- a/phpunit/unit/OAuth/TokenStorageTest.php
+++ b/phpunit/unit/OAuth/TokenStorageTest.php
@@ -173,7 +173,42 @@ class TokenStorageTest extends BaseTestCase {
 	}
 
 	/**
-	 * Test clear_tokens deletes all token-related options.
+	 * Test get_webhook_secret returns the stored webhook secret.
+	 */
+	public function testGetWebhookSecretReturnsStoredValue() {
+		WP_Mock::userFunction( 'get_option' )
+			->with( TokenStorage::WEBHOOK_SECRET_KEY, null )
+			->andReturn( 'test_webhook_secret' );
+
+		$this->assertEquals( 'test_webhook_secret', $this->token_storage->get_webhook_secret() );
+	}
+
+	/**
+	 * Test get_webhook_secret returns null when no secret is stored.
+	 */
+	public function testGetWebhookSecretReturnsNullWhenNotSet() {
+		WP_Mock::userFunction( 'get_option' )
+			->with( TokenStorage::WEBHOOK_SECRET_KEY, null )
+			->andReturn( null );
+
+		$this->assertNull( $this->token_storage->get_webhook_secret() );
+	}
+
+	/**
+	 * Test set_webhook_secret updates the webhook secret option.
+	 */
+	public function testSetWebhookSecretUpdatesOption() {
+		WP_Mock::userFunction( 'update_option' )
+			->with( TokenStorage::WEBHOOK_SECRET_KEY, 'new_webhook_secret', false )
+			->once();
+
+		$this->token_storage->set_webhook_secret( 'new_webhook_secret' );
+
+		$this->expectNotToPerformAssertions();
+	}
+
+	/**
+	 * Test clear_tokens deletes all token-related options including the webhook secret.
 	 */
 	public function testClearTokensDeletesAllOptions() {
 		WP_Mock::userFunction( 'delete_option' )
@@ -187,6 +222,9 @@ class TokenStorageTest extends BaseTestCase {
 			->once();
 		WP_Mock::userFunction( 'delete_option' )
 			->with( TokenStorage::CLIENT_ID_KEY )
+			->once();
+		WP_Mock::userFunction( 'delete_option' )
+			->with( TokenStorage::WEBHOOK_SECRET_KEY )
 			->once();
 
 		$this->token_storage->clear_tokens();

--- a/phpunit/unit/Webhook/WebhookControllerTest.php
+++ b/phpunit/unit/Webhook/WebhookControllerTest.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Tests the WebhookController class.
+ *
+ * @package OmniForm
+ */
+
+namespace OmniForm\Tests\Unit\Webhook;
+
+use Mockery;
+use OmniForm\OAuth\TokenStorage;
+use OmniForm\Tests\Unit\BaseTestCase;
+use OmniForm\Webhook\WebhookController;
+use WP_Error;
+use WP_Mock;
+use WP_REST_Request;
+
+/**
+ * Tests the WebhookController class.
+ */
+class WebhookControllerTest extends BaseTestCase {
+	/**
+	 * The TokenStorage mock.
+	 *
+	 * @var \Mockery\MockInterface|TokenStorage
+	 */
+	private $token_storage;
+
+	/**
+	 * The WebhookController instance.
+	 *
+	 * @var WebhookController
+	 */
+	private $controller;
+
+	/**
+	 * The signing secret used across tests.
+	 *
+	 * @var string
+	 */
+	private $secret = 'test_webhook_secret';
+
+	/**
+	 * Sets up the test environment before each test method is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		WP_Mock::userFunction( '__' )->andReturnUsing(
+			function ( $text ) {
+				return $text;
+			}
+		);
+
+		$this->token_storage = Mockery::mock( TokenStorage::class );
+		$this->controller    = new WebhookController( $this->token_storage );
+	}
+
+	/**
+	 * Tears down the test environment after each test method is executed.
+	 */
+	public function tearDown(): void {
+		Mockery::close();
+		parent::tearDown();
+	}
+
+	/**
+	 * Sign a raw body with the test secret.
+	 *
+	 * @param string $body The raw request body.
+	 *
+	 * @return string The hex HMAC-SHA256 signature.
+	 */
+	private function sign( $body ) {
+		return hash_hmac( 'sha256', $body, $this->secret );
+	}
+
+	/**
+	 * Build a mocked request with a body and signature header.
+	 *
+	 * @param string      $body      The raw request body.
+	 * @param string|null $signature The signature header value, or null to omit.
+	 *
+	 * @return \Mockery\MockInterface|WP_REST_Request
+	 */
+	private function build_request( $body, $signature = null ) {
+		$request = Mockery::mock( WP_REST_Request::class );
+		$request->shouldReceive( 'get_body' )->andReturn( $body );
+
+		$request->shouldReceive( 'get_header' )
+			->with( 'x_omniform_signature' )
+			->andReturn( $signature );
+
+		return $request;
+	}
+
+	/**
+	 * Test handle_webhook returns 403 when no webhook secret is configured.
+	 */
+	public function testHandleWebhookReturns403WhenNoSecret() {
+		$this->token_storage->shouldReceive( 'get_webhook_secret' )->andReturn( null );
+
+		$request = $this->build_request( '{}' );
+
+		$result = $this->controller->handle_webhook( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'omniform_webhook_not_configured', $result->get_error_code() );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Test handle_webhook returns 401 when the signature header is missing.
+	 */
+	public function testHandleWebhookReturns401WhenSignatureMissing() {
+		$this->token_storage->shouldReceive( 'get_webhook_secret' )->andReturn( $this->secret );
+
+		$request = $this->build_request( '{"type":"test"}', null );
+
+		$result = $this->controller->handle_webhook( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'omniform_webhook_missing_signature', $result->get_error_code() );
+		$this->assertSame( 401, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Test handle_webhook returns 401 when the signature does not match.
+	 */
+	public function testHandleWebhookReturns401WhenSignatureInvalid() {
+		$this->token_storage->shouldReceive( 'get_webhook_secret' )->andReturn( $this->secret );
+
+		$request = $this->build_request( '{"type":"test"}', 'deadbeef' );
+
+		$result = $this->controller->handle_webhook( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'omniform_webhook_invalid_signature', $result->get_error_code() );
+		$this->assertSame( 401, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Test handle_webhook returns 400 when the payload is missing the type field.
+	 */
+	public function testHandleWebhookReturns400WhenTypeMissing() {
+		$this->token_storage->shouldReceive( 'get_webhook_secret' )->andReturn( $this->secret );
+
+		$body    = '{"data":"no type here"}';
+		$request = $this->build_request( $body, $this->sign( $body ) );
+
+		$result = $this->controller->handle_webhook( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'omniform_webhook_invalid_payload', $result->get_error_code() );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Test handle_webhook returns 400 when the body is not valid JSON.
+	 */
+	public function testHandleWebhookReturns400WhenBodyNotJson() {
+		$this->token_storage->shouldReceive( 'get_webhook_secret' )->andReturn( $this->secret );
+
+		$body    = 'not json at all';
+		$request = $this->build_request( $body, $this->sign( $body ) );
+
+		$result = $this->controller->handle_webhook( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'omniform_webhook_invalid_payload', $result->get_error_code() );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Test handle_webhook fires the action and returns received on a valid request.
+	 */
+	public function testHandleWebhookFiresActionOnValidRequest() {
+		$this->token_storage->shouldReceive( 'get_webhook_secret' )->andReturn( $this->secret );
+
+		$body    = '{"type":"form.submitted","data":{"id":1}}';
+		$request = $this->build_request( $body, $this->sign( $body ) );
+
+		WP_Mock::expectAction(
+			'omniform_webhook_received',
+			array(
+				'type' => 'form.submitted',
+				'data' => array( 'id' => 1 ),
+			)
+		);
+
+		$result = $this->controller->handle_webhook( $request );
+
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertSame( array( 'received' => true ), $result );
+	}
+}


### PR DESCRIPTION
## Summary
Adds an inbound webhook endpoint so the OmniForm API can deliver async events to the site. Requests are authenticated with an HMAC-SHA256 signature over the raw body (the API cannot send a WordPress nonce), and verified events fire an action that extensions can hook into.

Fixes #74

## Changes

### New webhook endpoint
**Before:** No inbound webhook route existed. The plugin only made outbound calls to the API.

**After:**
```php
// includes/Webhook/WebhookController.php
register_rest_route( $this->namespace, '/' . $this->rest_base, array(
    'methods'             => WP_REST_Server::CREATABLE,
    'callback'            => array( $this, 'handle_webhook' ),
    'permission_callback' => array( $this, 'permissions_check' ),
) );
```
The handler checks the secret, verifies the `X-OmniForm-Signature` header with `hash_equals`, validates the payload has a string `type` field, then fires `omniform_webhook_received`.

**Why:** The endpoint is public because the API cannot mint a WP nonce, so the HMAC signature is the auth boundary instead of a capability check.

### Signing secret provisioning
**Before:** Only OAuth tokens (access, refresh, expiry) and the client ID were stored.

**After:**
```php
// includes/OAuth/TokenStorage.php
public function set_webhook_secret( string $secret ): void {
    update_option( self::WEBHOOK_SECRET_KEY, $secret, false );
}
```
`OAuthManager` reads `webhook_secret` from the token response on connect and on refresh, and stores it only when it is a non-empty string. The secret is cleared on disconnect. Stored with autoload disabled so it is not loaded on every request.

**Why:** There was no existing key suitable for verifying signatures, so the API provides one through the flow the plugin already runs.

### Wiring
`WebhookServiceProvider` (new) registers the controller and hooks `rest_api_init`, matching the `AnalyticsServiceProvider` pattern. Registered in `omniform.php` after `OAuthServiceProvider`.

## Testing

**Test 1: valid signature is accepted**
1. Complete the API connect flow so `omniform_webhook_secret` is set.
2. Sign a body and POST it with the `X-OmniForm-Signature` header.
```bash
SIG=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $2}')
curl -X POST "http://example.com/wp-json/omniform/v1/webhook" \
  -H "X-OmniForm-Signature: $SIG" --data "$BODY"
```
Result: `200` with `{"received":true}`, and the `omniform_webhook_received` action fires with the payload.

**Test 2: failure cases**
1. Missing signature header -> `401 omniform_webhook_missing_signature`.
2. Wrong signature -> `401 omniform_webhook_invalid_signature`.
3. Valid signature, body missing `type` -> `400 omniform_webhook_invalid_payload`.
4. No secret stored (disconnected) -> `403 omniform_webhook_not_configured`.

Result: each rejected with the expected status and code.

Automated: added unit tests for all six controller paths (403, 401 missing, 401 invalid, 400 missing type, 400 non-JSON, 200 happy path) plus TokenStorage webhook-secret coverage and an OAuthManager test that an empty `webhook_secret` field is ignored. Full suite passes (370 tests).